### PR TITLE
Refactor LEO mission tests and optimize gravity turn constraints

### DIFF
--- a/src/main/java/com/smousseur/orbitlab/engine/scene/planet/PlanetPresenter.java
+++ b/src/main/java/com/smousseur/orbitlab/engine/scene/planet/PlanetPresenter.java
@@ -35,12 +35,12 @@ public record PlanetPresenter(SolarSystemBody body, PlanetView view) {
         .ifPresent(
             posRotation -> {
               // Convertir en JME units/axes selon le contexte SOLAR
-              Vector3D pos = posRotation.getLeft();
+              Vector3D pos = posRotation.getFirst();
               Vector3D jmeUnitsJmeAxes =
                   RenderTransform.toRenderUnitsJmeAxes(pos, null, RenderContext.solar());
               Vector3f p = JmeVectorAdapter.toVector3f(jmeUnitsJmeAxes);
               view.setPositionWorld(p);
-              Rotation rotation = posRotation.getRight();
+              Rotation rotation = posRotation.getSecond();
               view.setRotationWorld(RenderTransform.toRenderQuaternion(rotation));
             });
   }

--- a/src/main/java/com/smousseur/orbitlab/simulation/ephemeris/service/EphemerisService.java
+++ b/src/main/java/com/smousseur/orbitlab/simulation/ephemeris/service/EphemerisService.java
@@ -2,7 +2,7 @@ package com.smousseur.orbitlab.simulation.ephemeris.service;
 
 import com.smousseur.orbitlab.core.SolarSystemBody;
 import com.smousseur.orbitlab.simulation.ephemeris.BodySample;
-import org.graalvm.collections.Pair;
+import org.hipparchus.util.Pair;
 import org.hipparchus.geometry.euclidean.threed.Rotation;
 import org.hipparchus.geometry.euclidean.threed.Vector3D;
 import org.orekit.time.AbsoluteDate;
@@ -16,12 +16,12 @@ public interface EphemerisService {
   default Optional<Pair<Vector3D, Rotation>> trySampleHelioIcrf(
       SolarSystemBody body, AbsoluteDate t) {
     if (body == SolarSystemBody.SUN) {
-      return Optional.of(Pair.create(Vector3D.ZERO, Rotation.IDENTITY));
+      return Optional.of(new Pair<>(Vector3D.ZERO, Rotation.IDENTITY));
     }
     Optional<BodySample> b = trySampleIcrf(body, t);
     Optional<BodySample> s = trySampleIcrf(SolarSystemBody.SUN, t);
     if (b.isEmpty() || s.isEmpty()) return Optional.empty();
     Vector3D position = b.get().pvIcrf().getPosition().subtract(s.get().pvIcrf().getPosition());
-    return Optional.of(Pair.create(position, b.get().rotationIcrf()));
+    return Optional.of(new Pair<>(position, b.get().rotationIcrf()));
   }
 }

--- a/src/main/java/com/smousseur/orbitlab/simulation/mission/optimizer/problems/GravityTurnConstraints.java
+++ b/src/main/java/com/smousseur/orbitlab/simulation/mission/optimizer/problems/GravityTurnConstraints.java
@@ -36,32 +36,32 @@ public record GravityTurnConstraints(
     t = FastMath.max(0, t); // clamp below
 
     // ── Anchor values (empirical) ──
-    // At 185 km: MECO ~55 km, apogee target ~150 km, max apogee ~178 km, FPA ~12°
-    // At 400 km: MECO  65 km, apogee target  170 km, max apogee  280 km, FPA  18°
+    // At 185 km: MECO ~50 km, apogee target ~155 km, max apogee ~200 km, FPA ~10°
+    // At 400 km: MECO  65 km, apogee target  200 km, max apogee  350 km, FPA  15°
 
     // Non-linear blend: use t^0.6 to give more weight to low-altitude behavior
     double blend = FastMath.pow(t, 0.6);
 
     // MECO altitude
-    double mecoAltitude = lerp(55_000, 65_000, blend);
-    mecoAltitude = FastMath.clamp(mecoAltitude, 50_000, 200_000);
+    double mecoAltitude = lerp(50_000, 65_000, blend);
+    mecoAltitude = FastMath.clamp(mecoAltitude, 45_000, 200_000);
 
-    // Target apogee — at low alt, apogee must be very close to target
-    double targetApogee = lerp(150_000, 170_000, blend);
-    targetApogee = FastMath.max(targetApogee, mecoAltitude * 1.5);
+    // Target apogee — wider window for better optimizer convergence
+    double targetApogee = lerp(155_000, 200_000, blend);
+    targetApogee = FastMath.max(targetApogee, mecoAltitude * 2.0);
 
-    // Max apogee — at low alt, very tight window; at high alt, more margin
-    double maxApogee = lerp(178_000, 280_000, blend);
-    maxApogee = FastMath.max(maxApogee, targetApogee * 1.15);
+    // Max apogee — generous window so the optimizer can explore freely
+    double maxApogee = lerp(200_000, 350_000, blend);
+    maxApogee = FastMath.max(maxApogee, targetApogee * 1.25);
 
-    // Min tangential velocity (~20% of v_circ at target)
+    // Min tangential velocity (~25% of v_circ at target)
     double rTarget = rEarth + missionTargetAltitude;
     double vCircTarget = FastMath.sqrt(mu / rTarget);
-    double minTangentialVelocity = vCircTarget * 0.20;
+    double minTangentialVelocity = vCircTarget * 0.25;
 
     // Flight path angle: lower orbit = more horizontal MECO
-    double fpa = lerp(12.0, 18.0, blend);
-    fpa = FastMath.clamp(fpa, 10.0, 28.0);
+    double fpa = lerp(10.0, 15.0, blend);
+    fpa = FastMath.clamp(fpa, 8.0, 28.0);
 
     return new GravityTurnConstraints(
         mecoAltitude, targetApogee, maxApogee, minTangentialVelocity, fpa);

--- a/src/main/java/com/smousseur/orbitlab/simulation/mission/optimizer/problems/GravityTurnProblem.java
+++ b/src/main/java/com/smousseur/orbitlab/simulation/mission/optimizer/problems/GravityTurnProblem.java
@@ -94,14 +94,14 @@ public class GravityTurnProblem implements TrajectoryProblem {
 
     // 2. Apogee window — this is the key for staging
     if (apogee < constraints.targetApogee()) {
-      cost += 8.0 * sq((constraints.targetApogee() - apogee) / constraints.targetApogee());
+      cost += 6.0 * sq((constraints.targetApogee() - apogee) / constraints.targetApogee());
     } else if (apogee > constraints.maxApogee()) {
-      cost += 3.0 * sq((apogee - constraints.maxApogee()) / constraints.targetApogee());
+      cost += 2.0 * sq((apogee - constraints.maxApogee()) / constraints.targetApogee());
     }
 
-    // 3. Flight path angle — small = nearly horizontal
+    // 3. Flight path angle — normalized by target for consistent scale across altitudes
     double targetFPA = Math.toRadians(constraints.targetFlightPathAngleDeg());
-    cost += 2.0 * sq(flightPathAngle - targetFPA);
+    cost += 5.0 * sq((flightPathAngle - targetFPA) / targetFPA);
 
     // 4. Tangential velocity — must be high enough for orbit insertion
     double minVtan = constraints.minTangentialVelocity();
@@ -109,15 +109,13 @@ public class GravityTurnProblem implements TrajectoryProblem {
       cost += 5.0 * sq((minVtan - vTangential) / minVtan);
     }
 
-    // 5. Smooth guard rails
     // 5. Smooth guard rails — scaled to mission constraints
     double minSafeAlt = constraints.targetAltitude() * 0.45;
-    if (alt < minSafeAlt) cost += 100.0 * sq((minSafeAlt - alt) / minSafeAlt);
+    if (alt < minSafeAlt) cost += 50.0 * sq((minSafeAlt - alt) / minSafeAlt);
     if (ecc > 1.0) cost += 100.0 * sq(ecc - 1.0);
-    double minSafeApogee = constraints.targetApogee() * 0.6;
+    double minSafeApogee = constraints.targetApogee() * 0.5;
     if (apogee < minSafeApogee) cost += 50.0 * sq((minSafeApogee - apogee) / minSafeApogee);
-    double minSafeVel = constraints.minTangentialVelocity() * 1.3;
-    if (vNorm < minSafeVel) cost += 100.0 * sq((minSafeVel - vNorm) / minSafeVel);
+    if (vNorm < minVtan) cost += 50.0 * sq((minVtan - vNorm) / minVtan);
 
     return cost;
   }

--- a/src/test/java/com/smousseur/orbitlab/simulation/mission/optimizer/LEOMissionOptimizationTest.java
+++ b/src/test/java/com/smousseur/orbitlab/simulation/mission/optimizer/LEOMissionOptimizationTest.java
@@ -31,7 +31,6 @@ public class LEOMissionOptimizationTest extends AbstractTrajectoryOptimizerTest 
   private static final Logger logger = LogManager.getLogger(LEOMissionOptimizationTest.class);
 
   public static final int ASCENSION_DURATION = 10;
-  public static final double TARGET_ALTITUDE = 400_000;
   public static final double ORBIT_MARGIN_RATIO = 0.07;
 
   @BeforeAll
@@ -40,28 +39,66 @@ public class LEOMissionOptimizationTest extends AbstractTrajectoryOptimizerTest 
   }
 
   @Test
-  void testLEOMission() {
+  void testLEOMission400km() {
+    runLEOMission(400_000);
+  }
+
+  @Test
+  void testLEOMission185km() {
+    runLEOMission(185_000);
+  }
+
+  private void runLEOMission(double targetAltitude) {
     AbsoluteDate epoch = new AbsoluteDate(2026, 1, 1, 12, 0, 0.0, TimeScalesFactory.getUTC());
     Mission mission =
         new AbstractTrajectoryOptimizerTest.TestMission(
-            "Gravity Turn", getStages(), getMissionVehicle(), 5.23, -52.77, 0.0, TARGET_ALTITUDE);
+            "Gravity Turn",
+            getStages(targetAltitude),
+            getMissionVehicle(),
+            5.23,
+            -52.77,
+            0.0,
+            targetAltitude);
     SpacecraftState initialState = mission.getInitialState(epoch);
     mission.setCurrentState(initialState);
     MissionOptimizer optimizer = new MissionOptimizer(mission);
     MissionOptimzerResult optimResults = optimizer.optimize();
     mission =
         new AbstractTrajectoryOptimizerTest.TestMission(
-            "Gravity Turn", getStages(), getMissionVehicle(), 5.23, -52.77, 0.0, TARGET_ALTITUDE);
+            "Gravity Turn",
+            getStages(targetAltitude),
+            getMissionVehicle(),
+            5.23,
+            -52.77,
+            0.0,
+            targetAltitude);
     initialState = mission.getInitialState(epoch);
     mission.setCurrentState(initialState);
     MissionPlayer player = new MissionPlayer(mission);
     player.play(optimResults, epoch);
     PropagationResults results = propagateMission(mission, "Coasting", epoch);
-    logger.info("Max coast altitude: {} m", results.maxCoastAltitude);
-    logger.info("Min coast altitude: {} m", results.minCoastAltitude);
-    double errorMargin = ORBIT_MARGIN_RATIO * TARGET_ALTITUDE;
-    Assertions.assertTrue(Math.abs(results.maxCoastAltitude - TARGET_ALTITUDE) <= errorMargin);
-    Assertions.assertTrue(Math.abs(results.minCoastAltitude - TARGET_ALTITUDE) <= errorMargin);
+    logger.info(
+        "Target: {} m — Max coast altitude: {} m, Min coast altitude: {} m",
+        targetAltitude,
+        results.maxCoastAltitude,
+        results.minCoastAltitude);
+    double errorMargin = ORBIT_MARGIN_RATIO * targetAltitude;
+    Assertions.assertTrue(
+        Math.abs(results.maxCoastAltitude - targetAltitude) <= errorMargin,
+        "Max coast altitude "
+            + results.maxCoastAltitude
+            + " exceeds margin of "
+            + errorMargin
+            + " from target "
+            + targetAltitude);
+    Assertions.assertTrue(
+        Math.abs(results.minCoastAltitude - targetAltitude) <= errorMargin,
+        "Min coast altitude "
+            + results.minCoastAltitude
+            + " exceeds margin of "
+            + errorMargin
+            + " from target "
+            + targetAltitude);
   }
 
   private static VehicleStack getMissionVehicle() {
@@ -73,16 +110,16 @@ public class LEOMissionOptimizationTest extends AbstractTrajectoryOptimizerTest 
                 Spacecraft.getSpacecraft())));
   }
 
-  private static List<MissionStage> getStages() {
+  private static List<MissionStage> getStages(double targetAltitude) {
     return List.of(
         new VerticalAscentStage("Vertical Ascent", ASCENSION_DURATION),
         new GravityTurnStage(
             "Gravity turn",
             ASCENSION_DURATION,
             3.0,
-            GravityTurnConstraints.forMissionAltitude(TARGET_ALTITUDE)),
+            GravityTurnConstraints.forMissionAltitude(targetAltitude)),
         new JettisonStage("Jettison"),
-        new TransfertTwoManeuverStage("Transfert", TARGET_ALTITUDE),
+        new TransfertTwoManeuverStage("Transfert", targetAltitude),
         new CoastingStage("Coasting", null));
   }
 }


### PR DESCRIPTION
## Summary
This PR refactors the LEO mission optimization tests to support multiple target altitudes and improves the gravity turn constraint tuning for better optimizer convergence across different orbital altitudes.

## Key Changes

### Test Refactoring
- Removed hardcoded `TARGET_ALTITUDE` constant and replaced with parameterized `runLEOMission(double targetAltitude)` method
- Added separate test cases for 400 km and 185 km target altitudes (`testLEOMission400km` and `testLEOMission185km`)
- Enhanced assertion messages with detailed error information showing target altitude, margins, and actual values
- Improved logging to display target altitude alongside coast altitude measurements

### Gravity Turn Constraint Tuning
- Updated empirical anchor values for 185 km and 400 km altitudes based on refined analysis
- Adjusted MECO altitude range (50-65 km) with relaxed lower bound (45 km vs 50 km)
- Widened target apogee window (155-200 km) for better optimizer convergence
- Increased max apogee margins (200-350 km) to allow more exploration freedom
- Increased minimum tangential velocity requirement from 20% to 25% of circular velocity

### Cost Function Optimization
- Reduced apogee undershoot penalty from 8.0 to 6.0 for better convergence
- Reduced apogee overshoot penalty from 3.0 to 2.0 to allow more flexibility
- Normalized flight path angle cost by target FPA for consistent scaling across altitudes
- Adjusted guard rail penalties: altitude (100→50), apogee (50 unchanged), velocity (100→50)
- Simplified velocity guard rail to use consistent minimum tangential velocity threshold

### Dependency Updates
- Migrated from deprecated `org.graalvm.collections.Pair` to `org.hipparchus.util.Pair`
- Updated `Pair` instantiation from `Pair.create()` to constructor `new Pair<>()`
- Updated accessor methods from `getLeft()`/`getRight()` to `getFirst()`/`getSecond()`

## Implementation Details
The refactoring enables testing across multiple LEO altitudes while maintaining a single optimization logic path. The constraint tuning changes prioritize optimizer convergence and exploration over tight constraint windows, particularly beneficial for lower altitude missions (185 km) which previously had overly restrictive bounds.

https://claude.ai/code/session_01BJgvFA4qWkDk2EBMbyaBBX