### PR TITLE
Add unit tests for non-JME simulation classes

### DIFF
--- a/src/main/java/com/smousseur/orbitlab/simulation/OrekitService.java
+++ b/src/main/java/com/smousseur/orbitlab/simulation/OrekitService.java
@@ -36,10 +36,7 @@ public final class OrekitService {
 
   private volatile ForceModel lightGravityModel;
 
-  private OrekitService() {
-    DataProvidersManager manager = DataContext.getDefault().getDataProvidersManager();
-    manager.addProvider(new ZipJarCrawler(OrekitService.class.getClassLoader(), "orekit-data.zip"));
-  }
+  private OrekitService() {}
 
   /**
    * Eagerly initializes the Orekit data context and loads reference frames.
@@ -50,7 +47,15 @@ public final class OrekitService {
     if (!initialized.compareAndSet(false, true)) {
       return;
     }
-    FramesFactory.getICRF();
+    try {
+      DataProvidersManager manager = DataContext.getDefault().getDataProvidersManager();
+      manager.addProvider(
+          new ZipJarCrawler(OrekitService.class.getClassLoader(), "orekit-data.zip"));
+      FramesFactory.getICRF();
+    } catch (RuntimeException e) {
+      initialized.set(false);
+      throw e;
+    }
   }
 
   /**

--- a/src/test/java/com/smousseur/orbitlab/simulation/PhysicsTest.java
+++ b/src/test/java/com/smousseur/orbitlab/simulation/PhysicsTest.java
@@ -1,0 +1,175 @@
+package com.smousseur.orbitlab.simulation;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.hipparchus.geometry.euclidean.threed.Vector3D;
+import org.hipparchus.util.FastMath;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.orekit.frames.Frame;
+import org.orekit.orbits.CartesianOrbit;
+import org.orekit.propagation.SpacecraftState;
+import org.orekit.time.AbsoluteDate;
+import org.orekit.utils.Constants;
+import org.orekit.utils.PVCoordinates;
+
+class PhysicsTest {
+
+  @BeforeAll
+  static void setup() {
+    Assumptions.assumeTrue(
+        OrekitService.class.getClassLoader().getResource("orekit-data.zip") != null,
+        "orekit-data.zip not on classpath — skipping");
+    OrekitService.get().initialize();
+  }
+
+  // --- computeBurnDuration ---
+
+  @Test
+  void computeBurnDuration_zeroDeltaV_returnsZero() {
+    assertEquals(0.0, Physics.computeBurnDuration(0, 1000, 300, 8_400_000), 1e-10);
+  }
+
+  @Test
+  void computeBurnDuration_matchesTsiolkovskyFormula() {
+    double isp = 300, mass = 10_000, thrust = 8_400_000, dv = 200;
+    double ve = isp * Constants.G0_STANDARD_GRAVITY;
+    double expected = (mass * ve / thrust) * (1.0 - FastMath.exp(-dv / ve));
+    assertEquals(expected, Physics.computeBurnDuration(dv, mass, isp, thrust), 1e-12);
+  }
+
+  @Test
+  void computeBurnDuration_largerDeltaV_longerDuration() {
+    double dt1 = Physics.computeBurnDuration(100, 10_000, 300, 8_400_000);
+    double dt2 = Physics.computeBurnDuration(500, 10_000, 300, 8_400_000);
+    assertTrue(dt2 > dt1);
+  }
+
+  // --- buildThrustDirectionTNW ---
+
+  @Test
+  void buildThrustDirectionTNW_zeroAngles_isPureTangential() {
+    Vector3D dir = Physics.buildThrustDirectionTNW(0.0, 0.0);
+    assertEquals(1.0, dir.getX(), 1e-12);
+    assertEquals(0.0, dir.getY(), 1e-12);
+    assertEquals(0.0, dir.getZ(), 1e-12);
+  }
+
+  @Test
+  void buildThrustDirectionTNW_isUnitVector() {
+    assertEquals(1.0, Physics.buildThrustDirectionTNW(0.3, 0.2).getNorm(), 1e-10);
+    assertEquals(1.0, Physics.buildThrustDirectionTNW(-0.5, 0.4).getNorm(), 1e-10);
+    assertEquals(1.0, Physics.buildThrustDirectionTNW(0.0, FastMath.PI / 4).getNorm(), 1e-10);
+  }
+
+  @Test
+  void buildThrustDirectionTNW_pureOutOfPlane_returnsPlusW() {
+    Vector3D dir = Physics.buildThrustDirectionTNW(0.0, FastMath.PI / 2);
+    assertEquals(0.0, dir.getX(), 1e-10);
+    assertEquals(0.0, dir.getY(), 1e-10);
+    assertEquals(1.0, dir.getZ(), 1e-10);
+  }
+
+  // --- getLaunchAzimuth ---
+
+  @Test
+  void getLaunchAzimuth_noArgs_returnsPiOver2() {
+    assertEquals(FastMath.PI / 2, Physics.getLaunchAzimuth(), 1e-12);
+  }
+
+  @Test
+  void getLaunchAzimuth_bothZero_returnsPiOver2() {
+    assertEquals(FastMath.PI / 2, Physics.getLaunchAzimuth(0, 0), 1e-12);
+  }
+
+  @Test
+  void getLaunchAzimuth_45degLatSameInclination_returnsPiOver2() {
+    // cos(45°) / cos(45°) = 1 → asin(1) = PI/2
+    double lat = FastMath.toRadians(45.0);
+    double incl = FastMath.toRadians(45.0);
+    assertEquals(FastMath.PI / 2, Physics.getLaunchAzimuth(lat, incl), 1e-10);
+  }
+
+  @Test
+  void getLaunchAzimuth_poleLatitude_throwsException() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> Physics.getLaunchAzimuth(FastMath.PI / 2, FastMath.toRadians(45.0)));
+  }
+
+  // --- computeRadialVelocity ---
+
+  @Test
+  void computeRadialVelocity_pureRadial_equalsVelocityMagnitude() {
+    Frame gcrf = OrekitService.get().gcrf();
+    PVCoordinates pv =
+        new PVCoordinates(new Vector3D(7_000_000, 0, 0), new Vector3D(1000, 0, 0));
+    SpacecraftState state =
+        new SpacecraftState(new CartesianOrbit(pv, gcrf, AbsoluteDate.J2000_EPOCH, Constants.WGS84_EARTH_MU));
+    assertEquals(1000.0, Physics.computeRadialVelocity(state), 1e-6);
+  }
+
+  @Test
+  void computeRadialVelocity_pureTangential_returnsZero() {
+    Frame gcrf = OrekitService.get().gcrf();
+    PVCoordinates pv =
+        new PVCoordinates(new Vector3D(7_000_000, 0, 0), new Vector3D(0, 7500, 0));
+    SpacecraftState state =
+        new SpacecraftState(new CartesianOrbit(pv, gcrf, AbsoluteDate.J2000_EPOCH, Constants.WGS84_EARTH_MU));
+    assertEquals(0.0, Physics.computeRadialVelocity(state), 1e-6);
+  }
+
+  // --- applyPitchKick ---
+
+  @Test
+  void applyPitchKick_zeroAngle_velocityUnchanged() {
+    Frame gcrf = OrekitService.get().gcrf();
+    PVCoordinates pv =
+        new PVCoordinates(new Vector3D(6_600_000, 0, 0), new Vector3D(0, 100, 200));
+    SpacecraftState state =
+        new SpacecraftState(
+                new CartesianOrbit(pv, gcrf, AbsoluteDate.J2000_EPOCH, Constants.WGS84_EARTH_MU))
+            .withMass(500_000);
+
+    SpacecraftState result = Physics.applyPitchKick(state, 0.0, FastMath.PI / 2);
+
+    Vector3D origVel = state.getPVCoordinates().getVelocity();
+    Vector3D newVel = result.getPVCoordinates().getVelocity();
+    assertEquals(origVel.getX(), newVel.getX(), 1e-6);
+    assertEquals(origVel.getY(), newVel.getY(), 1e-6);
+    assertEquals(origVel.getZ(), newVel.getZ(), 1e-6);
+  }
+
+  @Test
+  void applyPitchKick_massPreserved() {
+    Frame gcrf = OrekitService.get().gcrf();
+    PVCoordinates pv =
+        new PVCoordinates(new Vector3D(6_600_000, 0, 0), new Vector3D(0, 0, 300));
+    SpacecraftState state =
+        new SpacecraftState(
+                new CartesianOrbit(pv, gcrf, AbsoluteDate.J2000_EPOCH, Constants.WGS84_EARTH_MU))
+            .withMass(450_000);
+
+    SpacecraftState result = Physics.applyPitchKick(state, 0.05, FastMath.PI / 2);
+    assertEquals(450_000, result.getMass(), 1e-6);
+  }
+
+  @Test
+  void applyPitchKick_positionUnchanged() {
+    Frame gcrf = OrekitService.get().gcrf();
+    PVCoordinates pv =
+        new PVCoordinates(new Vector3D(6_600_000, 0, 0), new Vector3D(0, 0, 300));
+    SpacecraftState state =
+        new SpacecraftState(
+                new CartesianOrbit(pv, gcrf, AbsoluteDate.J2000_EPOCH, Constants.WGS84_EARTH_MU))
+            .withMass(450_000);
+
+    SpacecraftState result = Physics.applyPitchKick(state, 0.1, FastMath.PI / 2);
+    Vector3D origPos = state.getPVCoordinates().getPosition();
+    Vector3D newPos = result.getPVCoordinates().getPosition();
+    assertEquals(origPos.getX(), newPos.getX(), 1.0); // within 1m
+    assertEquals(origPos.getY(), newPos.getY(), 1.0);
+    assertEquals(origPos.getZ(), newPos.getZ(), 1.0);
+  }
+}

--- a/src/test/java/com/smousseur/orbitlab/simulation/ephemeris/SlidingWindowEphemerisBufferEnsureWindowTest.java
+++ b/src/test/java/com/smousseur/orbitlab/simulation/ephemeris/SlidingWindowEphemerisBufferEnsureWindowTest.java
@@ -1,0 +1,218 @@
+package com.smousseur.orbitlab.simulation.ephemeris;
+
+import static com.smousseur.orbitlab.core.SolarSystemBody.EARTH;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.smousseur.orbitlab.core.SolarSystemBody;
+import com.smousseur.orbitlab.simulation.ephemeris.config.EphemerisConfig;
+import com.smousseur.orbitlab.simulation.ephemeris.config.SlidingWindowConfig;
+import com.smousseur.orbitlab.simulation.source.EphemerisSource;
+import java.util.EnumMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.hipparchus.geometry.euclidean.threed.Rotation;
+import org.hipparchus.geometry.euclidean.threed.Vector3D;
+import org.junit.jupiter.api.Test;
+import org.orekit.time.AbsoluteDate;
+import org.orekit.utils.PVCoordinates;
+
+class SlidingWindowEphemerisBufferEnsureWindowTest {
+
+  private static EphemerisConfig minimalConfig() {
+    EnumMap<SolarSystemBody, Double> periods = new EnumMap<>(SolarSystemBody.class);
+    periods.put(EARTH, 1000.0);
+    return new EphemerisConfig(10.0, 2, 2, periods);
+  }
+
+  private static EphemerisSource countingSource(AtomicInteger counter) {
+    return (body, date) -> {
+      counter.incrementAndGet();
+      return new BodySample(date, PVCoordinates.ZERO, Rotation.IDENTITY);
+    };
+  }
+
+  private static SlidingWindowConfig.WindowPlan plan(int back, int fwd, int margin) {
+    return new SlidingWindowConfig.WindowPlan(10.0, back, fwd, margin);
+  }
+
+  // --- forceFullRebuild ---
+
+  @Test
+  void forceFullRebuild_true_alwaysRebuilds() {
+    AtomicInteger calls = new AtomicInteger();
+    SlidingWindowEphemerisBuffer buf =
+        new SlidingWindowEphemerisBuffer(countingSource(calls), minimalConfig(), EARTH);
+    SlidingWindowConfig.WindowPlan p = plan(10, 10, 4);
+    AbsoluteDate anchor = AbsoluteDate.J2000_EPOCH;
+
+    buf.ensureWindow(anchor, anchor.shiftedBy(100), 1.0, p, true);
+    int firstBuild = calls.get();
+    assertEquals(21, firstBuild); // 10+1+10
+
+    buf.ensureWindow(anchor, anchor.shiftedBy(100), 1.0, p, true);
+    assertEquals(firstBuild * 2, calls.get(), "forceFullRebuild should re-fetch all points");
+  }
+
+  // --- comfort zone ---
+
+  @Test
+  void nowInComfortZone_noRebuild() {
+    AtomicInteger calls = new AtomicInteger();
+    SlidingWindowEphemerisBuffer buf =
+        new SlidingWindowEphemerisBuffer(countingSource(calls), minimalConfig(), EARTH);
+    SlidingWindowConfig.WindowPlan p = plan(10, 10, 4);
+    AbsoluteDate anchor = AbsoluteDate.J2000_EPOCH;
+    AbsoluteDate now = anchor.shiftedBy(100);
+
+    // First build (s == null → full rebuild)
+    buf.ensureWindow(anchor, now, 1.0, p, false);
+    int afterFirstBuild = calls.get();
+
+    // Second call with same 'now' (still in comfort zone [40,160] with center=100)
+    buf.ensureWindow(anchor, now, 1.0, p, false);
+    assertEquals(afterFirstBuild, calls.get(), "In comfort zone: no source call expected");
+  }
+
+  @Test
+  void nowInComfortZone_windowUnchanged() {
+    SlidingWindowEphemerisBuffer buf =
+        new SlidingWindowEphemerisBuffer(
+            (body, date) -> new BodySample(date, PVCoordinates.ZERO, Rotation.IDENTITY),
+            minimalConfig(),
+            EARTH);
+    SlidingWindowConfig.WindowPlan p = plan(10, 10, 4);
+    AbsoluteDate anchor = AbsoluteDate.J2000_EPOCH;
+    AbsoluteDate now = anchor.shiftedBy(100);
+
+    buf.ensureWindow(anchor, now, 1.0, p, false);
+    SlidingWindowEphemerisBuffer.WindowInfo before = buf.windowInfo().orElseThrow();
+
+    buf.ensureWindow(anchor, now, 1.0, p, false);
+    SlidingWindowEphemerisBuffer.WindowInfo after = buf.windowInfo().orElseThrow();
+
+    assertEquals(before.start(), after.start());
+    assertEquals(before.end(), after.end());
+  }
+
+  // --- comfort zone exit → rebuild ---
+
+  @Test
+  void nowOutsideComfortZone_triggersRebuild() {
+    AtomicInteger calls = new AtomicInteger();
+    SlidingWindowEphemerisBuffer buf =
+        new SlidingWindowEphemerisBuffer(countingSource(calls), minimalConfig(), EARTH);
+    SlidingWindowConfig.WindowPlan p = plan(10, 10, 4);
+    AbsoluteDate anchor = AbsoluteDate.J2000_EPOCH;
+
+    // Build at center=100 → comfort zone [40, 160]
+    buf.ensureWindow(anchor, anchor.shiftedBy(100), 1.0, p, false);
+    calls.set(0);
+
+    // Move to t=200, well outside comfort zone → should trigger a rebuild
+    buf.ensureWindow(anchor, anchor.shiftedBy(200), 1.0, p, false);
+    assertTrue(calls.get() > 0, "Moving outside comfort zone should trigger source calls");
+  }
+
+  @Test
+  void nowOutsideComfortZone_windowMovesToCoverNow() {
+    SlidingWindowEphemerisBuffer buf =
+        new SlidingWindowEphemerisBuffer(
+            (body, date) -> new BodySample(date, PVCoordinates.ZERO, Rotation.IDENTITY),
+            minimalConfig(),
+            EARTH);
+    SlidingWindowConfig.WindowPlan p = plan(10, 10, 4);
+    AbsoluteDate anchor = AbsoluteDate.J2000_EPOCH;
+    AbsoluteDate far = anchor.shiftedBy(5000);
+
+    buf.ensureWindow(anchor, anchor.shiftedBy(100), 1.0, p, false);
+    buf.ensureWindow(anchor, far, 1.0, p, false);
+
+    SlidingWindowEphemerisBuffer.WindowInfo info = buf.windowInfo().orElseThrow();
+    assertTrue(
+        far.compareTo(info.start()) >= 0 && far.compareTo(info.end()) <= 0,
+        "New window should contain 'now'");
+  }
+
+  // --- plan change → full rebuild ---
+
+  @Test
+  void planChange_stepDiffers_triggersFullRebuild() {
+    AtomicInteger calls = new AtomicInteger();
+    SlidingWindowEphemerisBuffer buf =
+        new SlidingWindowEphemerisBuffer(countingSource(calls), minimalConfig(), EARTH);
+    AbsoluteDate anchor = AbsoluteDate.J2000_EPOCH;
+    AbsoluteDate now = anchor.shiftedBy(100);
+
+    SlidingWindowConfig.WindowPlan p1 = new SlidingWindowConfig.WindowPlan(10.0, 10, 10, 4);
+    buf.ensureWindow(anchor, now, 1.0, p1, false);
+    calls.set(0);
+
+    // Different step → plan incompatible → full rebuild
+    SlidingWindowConfig.WindowPlan p2 = new SlidingWindowConfig.WindowPlan(20.0, 10, 10, 4);
+    buf.ensureWindow(anchor, now, 1.0, p2, false);
+    assertEquals(21, calls.get(), "Step change should trigger full rebuild of 21 points");
+  }
+
+  // --- sliding (partial rebuild) ---
+
+  @Test
+  void smallShiftBackward_slidesPartially_fewerSourceCalls() {
+    AtomicInteger calls = new AtomicInteger();
+    EphemerisSource src =
+        (body, date) -> {
+          calls.incrementAndGet();
+          double t = date.durationFrom(AbsoluteDate.J2000_EPOCH);
+          return new BodySample(
+              date, new PVCoordinates(new Vector3D(t, 0, 0), Vector3D.ZERO), Rotation.IDENTITY);
+        };
+
+    SlidingWindowEphemerisBuffer buf =
+        new SlidingWindowEphemerisBuffer(src, minimalConfig(), EARTH);
+    // plan: back=10, fwd=10, margin=4 → window=[0,200] when center=100, comfort=[40,160]
+    SlidingWindowConfig.WindowPlan p = plan(10, 10, 4);
+    AbsoluteDate anchor = AbsoluteDate.J2000_EPOCH;
+
+    // Initial build: center=100 → start=0, 21 points fetched
+    buf.ensureWindow(anchor, anchor.shiftedBy(100), 1.0, p, false);
+    assertEquals(21, calls.get());
+
+    // Move 'now' to t=20 (left of comfort zone start at 40)
+    // targetIndex = 10 - 4 = 6, startCandidate = 20 - 60 = -40 → snapped to -40
+    // shiftSteps = -4 → |4| <= margin(4) → SLIDE, only 4 new points fetched
+    calls.set(0);
+    buf.ensureWindow(anchor, anchor.shiftedBy(20), 1.0, p, false);
+    assertEquals(4, calls.get(), "Small backward shift should only fetch new edge points");
+  }
+
+  @Test
+  void sliding_preservesInterpolatedValues_inOverlapRegion() {
+    // Build a source with distinct, time-varying positions
+    EphemerisSource src =
+        (body, date) -> {
+          double t = date.durationFrom(AbsoluteDate.J2000_EPOCH);
+          return new BodySample(
+              date,
+              new PVCoordinates(new Vector3D(t * 10, t * 20, 0), new Vector3D(10, 20, 0)),
+              Rotation.IDENTITY);
+        };
+
+    SlidingWindowEphemerisBuffer buf =
+        new SlidingWindowEphemerisBuffer(src, minimalConfig(), EARTH);
+    SlidingWindowConfig.WindowPlan p = plan(10, 10, 4);
+    AbsoluteDate anchor = AbsoluteDate.J2000_EPOCH;
+
+    // Build at center=100: window=[0,200]
+    buf.ensureWindow(anchor, anchor.shiftedBy(100), 1.0, p, false);
+
+    // Query a point in the overlap region before the slide (t=80)
+    AbsoluteDate queryT = anchor.shiftedBy(80);
+    double xBefore = buf.trySampleInterpolated(queryT).orElseThrow().pvIcrf().getPosition().getX();
+
+    // Slide backward (now=20)
+    buf.ensureWindow(anchor, anchor.shiftedBy(20), 1.0, p, false);
+
+    // After slide, new window: [-40, 160]. t=80 is still in window
+    double xAfter = buf.trySampleInterpolated(queryT).orElseThrow().pvIcrf().getPosition().getX();
+
+    assertEquals(xBefore, xAfter, 1e-6, "Overlap region values should be preserved after slide");
+  }
+}

--- a/src/test/java/com/smousseur/orbitlab/simulation/mission/attitude/GravityTurnAttitudeProviderTest.java
+++ b/src/test/java/com/smousseur/orbitlab/simulation/mission/attitude/GravityTurnAttitudeProviderTest.java
@@ -1,0 +1,127 @@
+package com.smousseur.orbitlab.simulation.mission.attitude;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.smousseur.orbitlab.simulation.OrekitService;
+import org.hipparchus.geometry.euclidean.threed.Rotation;
+import org.hipparchus.geometry.euclidean.threed.Vector3D;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.orekit.attitudes.Attitude;
+import org.orekit.frames.Frame;
+import org.orekit.time.AbsoluteDate;
+import org.orekit.utils.PVCoordinatesProvider;
+import org.orekit.utils.TimeStampedPVCoordinates;
+
+class GravityTurnAttitudeProviderTest {
+
+  private static Frame gcrf;
+
+  // Fixed PV: position along X (zenith=[1,0,0]), velocity along Y (horizDir=[0,1,0])
+  private static final PVCoordinatesProvider PV_PROV =
+      (date, frame) ->
+          new TimeStampedPVCoordinates(
+              date,
+              new Vector3D(7_000_000, 0, 0),
+              new Vector3D(0, 7500, 0),
+              Vector3D.ZERO);
+
+  @BeforeAll
+  static void setup() {
+    Assumptions.assumeTrue(
+        OrekitService.class.getClassLoader().getResource("orekit-data.zip") != null,
+        "orekit-data.zip not on classpath — skipping");
+    OrekitService.get().initialize();
+    gcrf = OrekitService.get().gcrf();
+  }
+
+  @Test
+  void returnedAttitude_isValid_noNaN() {
+    GravityTurnAttitudeProvider p =
+        new GravityTurnAttitudeProvider(AbsoluteDate.J2000_EPOCH, 200.0, 1.5);
+    Attitude att = p.getAttitude(PV_PROV, AbsoluteDate.J2000_EPOCH.shiftedBy(100), gcrf);
+    Rotation rot = att.getRotation();
+    assertFalse(Double.isNaN(rot.getQ0()));
+    assertFalse(Double.isNaN(rot.getQ1()));
+    assertFalse(Double.isNaN(rot.getQ2()));
+    assertFalse(Double.isNaN(rot.getQ3()));
+  }
+
+  @Test
+  void alphaClamped_wayBeforeKickDate_sameAsAtKickDate() {
+    AbsoluteDate kickDate = AbsoluteDate.J2000_EPOCH;
+    GravityTurnAttitudeProvider p = new GravityTurnAttitudeProvider(kickDate, 200.0, 1.0);
+
+    Attitude atKick = p.getAttitude(PV_PROV, kickDate, gcrf);
+    Attitude wayBefore = p.getAttitude(PV_PROV, kickDate.shiftedBy(-1000), gcrf);
+
+    assertEquals(0.0, Rotation.distance(atKick.getRotation(), wayBefore.getRotation()), 1e-10);
+  }
+
+  @Test
+  void alphaClamped_wayAfterTransition_sameAsAtTransitionEnd() {
+    AbsoluteDate kickDate = AbsoluteDate.J2000_EPOCH;
+    double transitionTime = 200.0;
+    GravityTurnAttitudeProvider p = new GravityTurnAttitudeProvider(kickDate, transitionTime, 1.0);
+
+    AbsoluteDate atEnd = kickDate.shiftedBy(transitionTime);
+    Attitude attAtEnd = p.getAttitude(PV_PROV, atEnd, gcrf);
+    Attitude attWayAfter = p.getAttitude(PV_PROV, kickDate.shiftedBy(transitionTime + 1000), gcrf);
+
+    assertEquals(0.0, Rotation.distance(attAtEnd.getRotation(), attWayAfter.getRotation()), 1e-10);
+  }
+
+  @Test
+  void attitudeChanges_significantly_throughTransition() {
+    AbsoluteDate kickDate = AbsoluteDate.J2000_EPOCH;
+    double transitionTime = 200.0;
+    GravityTurnAttitudeProvider p = new GravityTurnAttitudeProvider(kickDate, transitionTime, 1.0);
+
+    Attitude attStart = p.getAttitude(PV_PROV, kickDate, gcrf);
+    Attitude attEnd = p.getAttitude(PV_PROV, kickDate.shiftedBy(transitionTime), gcrf);
+
+    double totalAngle = Rotation.distance(attStart.getRotation(), attEnd.getRotation());
+    assertTrue(totalAngle > 0.5, "Attitude should rotate significantly (zenith → horizontal)");
+  }
+
+  @Test
+  void differentExponents_giveDifferentAttitudes_atMidpoint() {
+    AbsoluteDate kickDate = AbsoluteDate.J2000_EPOCH;
+    double transitionTime = 200.0;
+    AbsoluteDate midpoint = kickDate.shiftedBy(transitionTime / 2);
+
+    GravityTurnAttitudeProvider linear =
+        new GravityTurnAttitudeProvider(kickDate, transitionTime, 1.0);
+    GravityTurnAttitudeProvider quadratic =
+        new GravityTurnAttitudeProvider(kickDate, transitionTime, 2.0);
+
+    Attitude attLinear = linear.getAttitude(PV_PROV, midpoint, gcrf);
+    Attitude attQuadratic = quadratic.getAttitude(PV_PROV, midpoint, gcrf);
+
+    // exponent=2 lags behind exponent=1 at midpoint (slower start)
+    double angleDiff = Rotation.distance(attLinear.getRotation(), attQuadratic.getRotation());
+    assertTrue(angleDiff > 0.01, "Different exponents should give different attitudes at midpoint");
+  }
+
+  @Test
+  void attitudeIsMonotonicallyProgressing() {
+    AbsoluteDate kickDate = AbsoluteDate.J2000_EPOCH;
+    double transitionTime = 300.0;
+    GravityTurnAttitudeProvider p = new GravityTurnAttitudeProvider(kickDate, transitionTime, 1.0);
+
+    Attitude att0 = p.getAttitude(PV_PROV, kickDate, gcrf);
+    Attitude att1 = p.getAttitude(PV_PROV, kickDate.shiftedBy(100), gcrf);
+    Attitude att2 = p.getAttitude(PV_PROV, kickDate.shiftedBy(transitionTime), gcrf);
+
+    double d01 = Rotation.distance(att0.getRotation(), att1.getRotation());
+    double d12 = Rotation.distance(att1.getRotation(), att2.getRotation());
+    double d02 = Rotation.distance(att0.getRotation(), att2.getRotation());
+
+    // Total rotation = sum of partial rotations (approximately)
+    assertTrue(d01 > 0, "Should rotate in first segment");
+    assertTrue(d12 > 0, "Should rotate in second segment");
+    assertTrue(d02 > d01, "Total rotation greater than first segment");
+    assertTrue(d02 > d12, "Total rotation greater than second segment");
+  }
+}

--- a/src/test/java/com/smousseur/orbitlab/simulation/mission/attitude/ZenithThrustAttitudeProviderTest.java
+++ b/src/test/java/com/smousseur/orbitlab/simulation/mission/attitude/ZenithThrustAttitudeProviderTest.java
@@ -1,0 +1,109 @@
+package com.smousseur.orbitlab.simulation.mission.attitude;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.smousseur.orbitlab.simulation.OrekitService;
+import org.hipparchus.geometry.euclidean.threed.Rotation;
+import org.hipparchus.geometry.euclidean.threed.Vector3D;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.orekit.attitudes.Attitude;
+import org.orekit.frames.Frame;
+import org.orekit.time.AbsoluteDate;
+import org.orekit.utils.TimeStampedPVCoordinates;
+
+class ZenithThrustAttitudeProviderTest {
+
+  private static Frame gcrf;
+
+  @BeforeAll
+  static void setup() {
+    Assumptions.assumeTrue(
+        OrekitService.class.getClassLoader().getResource("orekit-data.zip") != null,
+        "orekit-data.zip not on classpath — skipping");
+    OrekitService.get().initialize();
+    gcrf = OrekitService.get().gcrf();
+  }
+
+  private static TimeStampedPVCoordinates tpv(AbsoluteDate date, Vector3D pos, Vector3D vel) {
+    return new TimeStampedPVCoordinates(date, pos, vel, Vector3D.ZERO);
+  }
+
+  @Test
+  void returnedAttitude_isValid_noNaN() {
+    ZenithThrustAttitudeProvider p = new ZenithThrustAttitudeProvider(gcrf);
+    AbsoluteDate date = AbsoluteDate.J2000_EPOCH;
+    Attitude att =
+        p.getAttitude(
+            (d, f) -> tpv(d, new Vector3D(7_000_000, 1_000_000, 500_000), Vector3D.ZERO),
+            date,
+            gcrf);
+    Rotation rot = att.getRotation();
+    assertFalse(Double.isNaN(rot.getQ0()));
+    assertFalse(Double.isNaN(rot.getQ1()));
+    assertFalse(Double.isNaN(rot.getQ2()));
+    assertFalse(Double.isNaN(rot.getQ3()));
+  }
+
+  @Test
+  void samePosition_differentVelocity_sameAttitude() {
+    ZenithThrustAttitudeProvider p = new ZenithThrustAttitudeProvider(gcrf);
+    Vector3D pos = new Vector3D(7_000_000, 0, 0);
+    AbsoluteDate date = AbsoluteDate.J2000_EPOCH;
+
+    Attitude att1 = p.getAttitude((d, f) -> tpv(d, pos, new Vector3D(0, 7500, 0)), date, gcrf);
+    Attitude att2 = p.getAttitude((d, f) -> tpv(d, pos, new Vector3D(0, 5000, 100)), date, gcrf);
+
+    assertEquals(0.0, Rotation.distance(att1.getRotation(), att2.getRotation()), 1e-10);
+  }
+
+  @Test
+  void differentPositions_giveDifferentAttitudes() {
+    ZenithThrustAttitudeProvider p = new ZenithThrustAttitudeProvider(gcrf);
+    AbsoluteDate date = AbsoluteDate.J2000_EPOCH;
+
+    Attitude att1 =
+        p.getAttitude(
+            (d, f) -> tpv(d, new Vector3D(7_000_000, 0, 0), Vector3D.ZERO), date, gcrf);
+    Attitude att2 =
+        p.getAttitude(
+            (d, f) -> tpv(d, new Vector3D(0, 7_000_000, 0), Vector3D.ZERO), date, gcrf);
+
+    double angleDiff = Rotation.distance(att1.getRotation(), att2.getRotation());
+    assertTrue(angleDiff > 0.5, "Orthogonal positions should give very different zenith attitudes");
+  }
+
+  @Test
+  void positionAlongPoleAxis_usesValidFallback() {
+    // Position exactly along Z (north pole): cross product with PLUS_K = zero → fallback used
+    ZenithThrustAttitudeProvider p = new ZenithThrustAttitudeProvider(gcrf);
+    AbsoluteDate date = AbsoluteDate.J2000_EPOCH;
+
+    Attitude att =
+        p.getAttitude(
+            (d, f) -> tpv(d, new Vector3D(0, 0, 7_000_000), Vector3D.ZERO), date, gcrf);
+
+    Rotation rot = att.getRotation();
+    assertFalse(Double.isNaN(rot.getQ0()));
+    assertFalse(Double.isNaN(rot.getQ1()));
+    assertFalse(Double.isNaN(rot.getQ2()));
+    assertFalse(Double.isNaN(rot.getQ3()));
+  }
+
+  @Test
+  void samePositionAtDifferentDates_sameAttitude() {
+    // Attitude depends only on position, not time
+    ZenithThrustAttitudeProvider p = new ZenithThrustAttitudeProvider(gcrf);
+    Vector3D pos = new Vector3D(7_000_000, 0, 0);
+
+    Attitude att1 =
+        p.getAttitude(
+            (d, f) -> tpv(d, pos, Vector3D.ZERO), AbsoluteDate.J2000_EPOCH, gcrf);
+    Attitude att2 =
+        p.getAttitude(
+            (d, f) -> tpv(d, pos, Vector3D.ZERO), AbsoluteDate.J2000_EPOCH.shiftedBy(3600), gcrf);
+
+    assertEquals(0.0, Rotation.distance(att1.getRotation(), att2.getRotation()), 1e-10);
+  }
+}

--- a/src/test/java/com/smousseur/orbitlab/simulation/mission/optimizer/AdaptiveConvergenceCheckerTest.java
+++ b/src/test/java/com/smousseur/orbitlab/simulation/mission/optimizer/AdaptiveConvergenceCheckerTest.java
@@ -1,0 +1,101 @@
+package com.smousseur.orbitlab.simulation.mission.optimizer;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.hipparchus.optim.PointValuePair;
+import org.junit.jupiter.api.Test;
+
+class AdaptiveConvergenceCheckerTest {
+
+  private static PointValuePair pair(double value) {
+    return new PointValuePair(new double[] {0.0}, value);
+  }
+
+  /** Calls converged() n times with the given cost value (both previous and current). */
+  private static void burn(AdaptiveConvergenceChecker checker, int n, double cost) {
+    PointValuePair p = pair(cost);
+    for (int i = 0; i < n; i++) {
+      checker.converged(i, p, p);
+    }
+  }
+
+  @Test
+  void doesNotConverge_beforeMinIterations() {
+    AdaptiveConvergenceChecker checker = new AdaptiveConvergenceChecker(false, 0.1, 1e-6, 1e-6);
+    // Even with zero diff and cost below acceptable, never converge before 100 calls
+    for (int i = 0; i < 99; i++) {
+      assertFalse(
+          checker.converged(i, pair(0.0), pair(0.0)),
+          "Should not converge at iterationCount=" + (i + 1));
+    }
+  }
+
+  @Test
+  void earlyKill_activates_after300IterationsWithHighCost() {
+    AdaptiveConvergenceChecker checker = new AdaptiveConvergenceChecker(true, 0.1, 1e-6, 1e-6);
+    PointValuePair bad = pair(2.0); // cost > BAD_BASIN_KILL_THRESHOLD (1.0)
+    // Need iterationCount > 300 to trigger early kill
+    burn(checker, 301, 2.0);
+    assertTrue(checker.converged(301, bad, bad), "Early kill should activate after 301 iterations with bad cost");
+  }
+
+  @Test
+  void earlyKill_disabled_doesNotKillAfter300() {
+    AdaptiveConvergenceChecker checker = new AdaptiveConvergenceChecker(false, 0.1, 1e-6, 1e-6);
+    PointValuePair bad = pair(2.0);
+    burn(checker, 301, 2.0);
+    // cost > acceptable (0.1), iterationCount (302) < 500 → no convergence
+    assertFalse(checker.converged(301, bad, bad), "Without earlyKill, should not terminate at 302");
+  }
+
+  @Test
+  void doesNotConverge_prematurely_whenCostAboveAcceptable_before500() {
+    AdaptiveConvergenceChecker checker = new AdaptiveConvergenceChecker(false, 0.1, 1e-6, 1e-6);
+    PointValuePair mediocre = pair(0.5); // cost > acceptable (0.1)
+    // Reach 101 iterations (past the 100 min)
+    burn(checker, 100, 0.5);
+    // At 101st call: cost=0.5 > 0.1 and iterationCount=101 < 500 → false
+    assertFalse(checker.converged(100, mediocre, mediocre),
+        "Should not converge when cost > acceptable and iters < 500");
+  }
+
+  @Test
+  void converges_whenCostBelowAcceptable_andSmallImprovement() {
+    AdaptiveConvergenceChecker checker = new AdaptiveConvergenceChecker(false, 0.1, 1e-6, 1e-6);
+    PointValuePair good = pair(0.05); // cost < acceptable (0.1)
+    // Reach 100 iterations
+    burn(checker, 100, 0.05);
+    // At 101st call: diff=0 <= absoluteTolerance → converge
+    assertTrue(checker.converged(100, good, good),
+        "Should converge when cost < acceptable and diff <= absoluteTolerance");
+  }
+
+  @Test
+  void converges_via_relativeImprovement() {
+    AdaptiveConvergenceChecker checker = new AdaptiveConvergenceChecker(false, 0.1, 0.0, 0.01);
+    PointValuePair good = pair(0.05);
+    burn(checker, 100, 0.05);
+    // diff=0, 0 <= 0.01 * 0.05 = 5e-4 → converge
+    assertTrue(checker.converged(100, good, good));
+  }
+
+  @Test
+  void doesNotConverge_whenImprovementAboveTolerance() {
+    AdaptiveConvergenceChecker checker = new AdaptiveConvergenceChecker(false, 0.1, 1e-6, 1e-6);
+    // Reach 100 iterations with cost below acceptable
+    burn(checker, 100, 0.05);
+    // Large diff between previous (0.5) and current (0.05): 0.45 >> 1e-6
+    assertFalse(checker.converged(100, pair(0.5), pair(0.05)),
+        "Should not converge when diff is above tolerance");
+  }
+
+  @Test
+  void earlyKill_requiresCostAboveThreshold() {
+    AdaptiveConvergenceChecker checker = new AdaptiveConvergenceChecker(true, 0.1, 1e-6, 1e-6);
+    // Run past 300 iters but with cost BELOW the bad-basin threshold (1.0)
+    burn(checker, 301, 0.5); // 0.5 < 1.0
+    // Should NOT early-kill; cost (0.5) > acceptable (0.1), iters (302) < 500 → false
+    assertFalse(checker.converged(301, pair(0.5), pair(0.5)),
+        "Early kill should not activate when cost is below bad-basin threshold");
+  }
+}

--- a/src/test/java/com/smousseur/orbitlab/simulation/mission/optimizer/problems/GravityTurnProblemTest.java
+++ b/src/test/java/com/smousseur/orbitlab/simulation/mission/optimizer/problems/GravityTurnProblemTest.java
@@ -1,0 +1,151 @@
+package com.smousseur.orbitlab.simulation.mission.optimizer.problems;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.smousseur.orbitlab.simulation.OrekitService;
+import com.smousseur.orbitlab.simulation.mission.maneuver.GravityTurnManeuver;
+import com.smousseur.orbitlab.simulation.mission.vehicle.LaunchVehicle;
+import com.smousseur.orbitlab.simulation.mission.vehicle.Vehicle;
+import org.hipparchus.geometry.euclidean.threed.Vector3D;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.orekit.frames.Frame;
+import org.orekit.orbits.CartesianOrbit;
+import org.orekit.propagation.SpacecraftState;
+import org.orekit.time.AbsoluteDate;
+import org.orekit.utils.Constants;
+import org.orekit.utils.PVCoordinates;
+
+class GravityTurnProblemTest {
+
+  private static GravityTurnManeuver maneuver;
+
+  @BeforeAll
+  static void setup() {
+    Assumptions.assumeTrue(
+        OrekitService.class.getClassLoader().getResource("orekit-data.zip") != null,
+        "orekit-data.zip not on classpath — skipping");
+    OrekitService.get().initialize();
+    Vehicle vehicle = LaunchVehicle.getLauncherStage1Vehicle();
+    maneuver = new GravityTurnManeuver(vehicle, 0, 0, Math.PI / 2);
+  }
+
+  @Test
+  void getNumVariables_returnsTwo() {
+    GravityTurnProblem p = new GravityTurnProblem(maneuver, null, null);
+    assertEquals(2, p.getNumVariables());
+  }
+
+  @Test
+  void getLowerBounds_correctValues() {
+    GravityTurnProblem p = new GravityTurnProblem(maneuver, null, null);
+    double[] bounds = p.getLowerBounds();
+    assertEquals(2, bounds.length);
+    assertEquals(30.0, bounds[0], 1e-10);
+    assertEquals(0.3, bounds[1], 1e-10);
+  }
+
+  @Test
+  void getUpperBounds_correctValues() {
+    GravityTurnProblem p = new GravityTurnProblem(maneuver, null, null);
+    double[] bounds = p.getUpperBounds();
+    assertEquals(2, bounds.length);
+    assertEquals(450.0, bounds[0], 1e-10);
+    assertEquals(3.0, bounds[1], 1e-10);
+  }
+
+  @Test
+  void getInitialSigma_correctValues() {
+    GravityTurnProblem p = new GravityTurnProblem(maneuver, null, null);
+    double[] sigma = p.getInitialSigma();
+    assertEquals(2, sigma.length);
+    assertEquals(30.0, sigma[0], 1e-10);
+    assertEquals(0.3, sigma[1], 1e-10);
+  }
+
+  @Test
+  void getAcceptableCost_returnsTightThreshold() {
+    GravityTurnProblem p = new GravityTurnProblem(maneuver, null, null);
+    assertEquals(1e-4, p.getAcceptableCost(), 1e-12);
+  }
+
+  @Test
+  void buildInitialGuess_withinBounds() {
+    GravityTurnProblem p = new GravityTurnProblem(maneuver, null, null);
+    double[] guess = p.buildInitialGuess();
+    double[] lower = p.getLowerBounds();
+    double[] upper = p.getUpperBounds();
+
+    assertEquals(2, guess.length);
+    // transitionTime
+    assertTrue(guess[0] >= lower[0], "transitionTime guess should be >= lower bound");
+    assertTrue(guess[0] <= upper[0], "transitionTime guess should be <= upper bound");
+    // exponent
+    assertEquals(1.0, guess[1], 1e-10);
+  }
+
+  @Test
+  void computeCost_lowerAltitudeState_hasHigherCost() {
+    // The cost function penalizes apogee below target window
+    Frame gcrf = OrekitService.get().gcrf();
+    AbsoluteDate date = AbsoluteDate.J2000_EPOCH;
+    GravityTurnConstraints constraints = GravityTurnConstraints.forTarget(400_000);
+
+    // State 1: ~150km circular orbit — apogee well below target (300km)
+    double r1 = Constants.WGS84_EARTH_EQUATORIAL_RADIUS + 150_000;
+    double v1 = Math.sqrt(Constants.WGS84_EARTH_MU / r1);
+    SpacecraftState state1 =
+        new SpacecraftState(
+                new CartesianOrbit(
+                    new PVCoordinates(new Vector3D(r1, 0, 0), new Vector3D(0, v1, 0)),
+                    gcrf,
+                    date,
+                    Constants.WGS84_EARTH_MU))
+            .withMass(10_000);
+
+    // State 2: ~325km circular orbit — apogee inside [300km, 350km] target window
+    double r2 = Constants.WGS84_EARTH_EQUATORIAL_RADIUS + 325_000;
+    double v2 = Math.sqrt(Constants.WGS84_EARTH_MU / r2);
+    SpacecraftState state2 =
+        new SpacecraftState(
+                new CartesianOrbit(
+                    new PVCoordinates(new Vector3D(r2, 0, 0), new Vector3D(0, v2, 0)),
+                    gcrf,
+                    date,
+                    Constants.WGS84_EARTH_MU))
+            .withMass(10_000);
+
+    GravityTurnProblem problem = new GravityTurnProblem(maneuver, state1, constraints);
+    double cost1 = problem.computeCost(state1);
+    double cost2 = problem.computeCost(state2);
+
+    assertTrue(cost1 > 0, "Cost should be positive for sub-target orbit");
+    assertTrue(cost2 >= 0, "Cost should be non-negative");
+    assertTrue(cost1 > cost2, "Lower altitude (further from target) should have higher cost");
+  }
+
+  @Test
+  void computeCost_hyperbolicOrbit_hasHighCost() {
+    Frame gcrf = OrekitService.get().gcrf();
+    AbsoluteDate date = AbsoluteDate.J2000_EPOCH;
+    GravityTurnConstraints constraints = GravityTurnConstraints.forTarget(400_000);
+
+    // Escape velocity state: very high speed → hyperbolic trajectory
+    double r = Constants.WGS84_EARTH_EQUATORIAL_RADIUS + 300_000;
+    double vEscape = Math.sqrt(2 * Constants.WGS84_EARTH_MU / r) * 1.1; // 10% above escape velocity
+    SpacecraftState hyperbolicState =
+        new SpacecraftState(
+                new CartesianOrbit(
+                    new PVCoordinates(new Vector3D(r, 0, 0), new Vector3D(0, vEscape, 0)),
+                    gcrf,
+                    date,
+                    Constants.WGS84_EARTH_MU))
+            .withMass(10_000);
+
+    GravityTurnProblem problem = new GravityTurnProblem(maneuver, hyperbolicState, constraints);
+    double cost = problem.computeCost(hyperbolicState);
+
+    assertTrue(cost > 10.0, "Hyperbolic orbit should incur a large penalty cost");
+  }
+}

--- a/src/test/java/com/smousseur/orbitlab/simulation/mission/vehicle/VehicleTest.java
+++ b/src/test/java/com/smousseur/orbitlab/simulation/mission/vehicle/VehicleTest.java
@@ -1,0 +1,144 @@
+package com.smousseur.orbitlab.simulation.mission.vehicle;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.smousseur.orbitlab.core.OrbitlabException;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.orekit.utils.Constants;
+
+class VehicleTest {
+
+  // --- PropulsionSystem ---
+
+  @Test
+  void propulsionSystem_massBurnt_matchesRocketEquation() {
+    // massBurnt = (thrust / (isp * G0)) * duration
+    PropulsionSystem p = new PropulsionSystem(300, 8_400_000);
+    double flowRate = 8_400_000 / (300 * Constants.G0_STANDARD_GRAVITY);
+    double expected = flowRate * 10.0; // 10 seconds
+    assertEquals(expected, p.massBurnt(10.0), 1e-6);
+  }
+
+  @Test
+  void propulsionSystem_massBurnt_zeroDuration_returnsZero() {
+    assertEquals(0.0, new PropulsionSystem(300, 8_400_000).massBurnt(0.0), 1e-10);
+  }
+
+  @Test
+  void propulsionSystem_massBurnt_isLinearInDuration() {
+    PropulsionSystem p = PropulsionSystem.getLauncherStage1Propulsion();
+    double m1 = p.massBurnt(1.0);
+    double m10 = p.massBurnt(10.0);
+    assertEquals(10 * m1, m10, 1e-6);
+  }
+
+  @Test
+  void propulsionSystem_higherIsp_lessConsumption_sameDuration() {
+    PropulsionSystem lowIsp = new PropulsionSystem(300, 1_000_000);
+    PropulsionSystem highIsp = new PropulsionSystem(400, 1_000_000);
+    assertTrue(lowIsp.massBurnt(60) > highIsp.massBurnt(60),
+        "Higher Isp should consume less propellant");
+  }
+
+  // --- LaunchVehicle ---
+
+  @Test
+  void launchVehicle_getMass_equalsDryPlusPropellant() {
+    LaunchVehicle v = LaunchVehicle.getLauncherStage1Vehicle();
+    assertEquals(v.dryMass() + v.propellantCapacity(), v.getMass(), 1e-6);
+  }
+
+  @Test
+  void launchVehicle_stage1_knownValues() {
+    LaunchVehicle v = LaunchVehicle.getLauncherStage1Vehicle();
+    assertEquals(27_000, v.dryMass(), 1e-6);
+    assertEquals(425_000, v.propellantCapacity(), 1e-6);
+    assertEquals(452_000, v.getMass(), 1e-6);
+  }
+
+  @Test
+  void launchVehicle_stage2_knownValues() {
+    LaunchVehicle v = LaunchVehicle.getLauncherStage2Vehicle();
+    assertEquals(10_000, v.dryMass(), 1e-6);
+    assertEquals(134_000, v.propellantCapacity(), 1e-6);
+    assertEquals(144_000, v.getMass(), 1e-6);
+  }
+
+  @Test
+  void launchVehicle_getStage_returnsItself() {
+    LaunchVehicle v = LaunchVehicle.getLauncherStage1Vehicle();
+    assertSame(v, v.getStage(0));
+    assertSame(v, v.getStage(1));
+  }
+
+  @Test
+  void launchVehicle_jettison_throwsException() {
+    LaunchVehicle v = LaunchVehicle.getLauncherStage1Vehicle();
+    assertThrows(OrbitlabException.class, v::jettison);
+  }
+
+  // --- VehicleStack ---
+
+  @Test
+  void vehicleStack_getMass_sumOfAllStages() {
+    LaunchVehicle s1 = LaunchVehicle.getLauncherStage1Vehicle();
+    LaunchVehicle s2 = LaunchVehicle.getLauncherStage2Vehicle();
+    VehicleStack stack = new VehicleStack(List.of(s1, s2));
+    assertEquals(s1.getMass() + s2.getMass(), stack.getMass(), 1e-6);
+  }
+
+  @Test
+  void vehicleStack_dryMass_sumOfAllDryMasses() {
+    LaunchVehicle s1 = LaunchVehicle.getLauncherStage1Vehicle();
+    LaunchVehicle s2 = LaunchVehicle.getLauncherStage2Vehicle();
+    VehicleStack stack = new VehicleStack(List.of(s1, s2));
+    assertEquals(s1.dryMass() + s2.dryMass(), stack.dryMass(), 1e-6);
+  }
+
+  @Test
+  void vehicleStack_propulsion_delegatesToFirstStage() {
+    LaunchVehicle s1 = LaunchVehicle.getLauncherStage1Vehicle();
+    LaunchVehicle s2 = LaunchVehicle.getLauncherStage2Vehicle();
+    VehicleStack stack = new VehicleStack(List.of(s1, s2));
+    assertEquals(s1.propulsion().isp(), stack.propulsion().isp(), 1e-6);
+    assertEquals(s1.propulsion().thrust(), stack.propulsion().thrust(), 1e-6);
+  }
+
+  @Test
+  void vehicleStack_jettison_removesFirstStage() {
+    LaunchVehicle s1 = LaunchVehicle.getLauncherStage1Vehicle();
+    LaunchVehicle s2 = LaunchVehicle.getLauncherStage2Vehicle();
+    VehicleStack stack = new VehicleStack(List.of(s1, s2));
+
+    double massBefore = stack.getMass();
+    stack.jettison(0);
+
+    assertEquals(massBefore - s1.getMass(), stack.getMass(), 1e-6);
+    assertEquals(s2.getMass(), stack.getMass(), 1e-6);
+  }
+
+  @Test
+  void vehicleStack_jettison_updatesActivePropulsion() {
+    LaunchVehicle s1 = LaunchVehicle.getLauncherStage1Vehicle();
+    LaunchVehicle s2 = LaunchVehicle.getLauncherStage2Vehicle();
+    VehicleStack stack = new VehicleStack(List.of(s1, s2));
+
+    stack.jettison(0);
+
+    // After jettison, s2 is now first → its propulsion is active
+    assertEquals(s2.propulsion().isp(), stack.propulsion().isp(), 1e-6);
+    assertEquals(s2.propulsion().thrust(), stack.propulsion().thrust(), 1e-6);
+  }
+
+  @Test
+  void vehicleStack_defensiveCopy_externalMutationNotReflected() {
+    LaunchVehicle s1 = LaunchVehicle.getLauncherStage1Vehicle();
+    LaunchVehicle s2 = LaunchVehicle.getLauncherStage2Vehicle();
+    java.util.ArrayList<Vehicle> list = new java.util.ArrayList<>(List.of(s1, s2));
+    VehicleStack stack = new VehicleStack(list);
+
+    list.clear(); // mutate external list
+    assertEquals(2, stack.vehicles().size(), "Stack should be independent from external list");
+  }
+}


### PR DESCRIPTION
New test classes:
- PhysicsTest: computeBurnDuration (Tsiolkovsky), buildThrustDirectionTNW, getLaunchAzimuth, computeRadialVelocity, applyPitchKick
- GravityTurnAttitudeProviderTest: clamping, power-law interpolation, monotonic progression, exponent effect
- ZenithThrustAttitudeProviderTest: zenith direction, pole fallback, position-only dependency
- AdaptiveConvergenceCheckerTest: early kill, convergence thresholds, min iteration guard
- GravityTurnProblemTest: bounds, initial guess, cost function ordering
- VehicleTest: PropulsionSystem, LaunchVehicle, VehicleStack jettison
- SlidingWindowEphemerisBufferEnsureWindowTest: comfort zone, force rebuild, plan change, partial slide, overlap preservation

Also move ZipJarCrawler registration from OrekitService constructor into initialize() to prevent static-init cascade failures when orekit-data.zip is absent. Orekit-dependent tests skip gracefully via assumeTrue.

https://claude.ai/code/session_01JHAQdSrEtDXACXEaGDrFvM