### PR TITLE
Refactor vehicle stage system: replace explicit stage lookups

### DIFF
--- a/src/main/java/com/smousseur/orbitlab/simulation/mission/maneuver/Burn2Resolver.java
+++ b/src/main/java/com/smousseur/orbitlab/simulation/mission/maneuver/Burn2Resolver.java
@@ -2,6 +2,7 @@ package com.smousseur.orbitlab.simulation.mission.maneuver;
 
 import com.smousseur.orbitlab.simulation.OrekitService;
 import com.smousseur.orbitlab.simulation.Physics;
+import com.smousseur.orbitlab.simulation.mission.vehicle.ActiveStageInfo;
 import com.smousseur.orbitlab.simulation.mission.vehicle.PropulsionSystem;
 import com.smousseur.orbitlab.simulation.mission.vehicle.Vehicle;
 import org.hipparchus.util.FastMath;
@@ -14,7 +15,8 @@ import org.orekit.propagation.numerical.NumericalPropagator;
 /**
  * Resolves burn 2 (circularization at next apoapsis) deterministically from a post-burn-1 state.
  *
- * <p>Pure computation — no mutable state.
+ * <p>Pure computation — no mutable state. The active stage propulsion is resolved automatically
+ * from the spacecraft mass via {@link Vehicle#resolveActiveStage(double)}.
  */
 final class Burn2Resolver {
 
@@ -61,7 +63,8 @@ final class Burn2Resolver {
       return new TransfertTwoManeuver.ResolvedBurn2(dtApoapsis, 0.0, 0.0);
     }
 
-    PropulsionSystem propulsion = vehicle.getSecondStage().propulsion();
+    ActiveStageInfo stage = vehicle.resolveActiveStage(stateAfterBurn1.getMass());
+    PropulsionSystem propulsion = stage.propulsion();
     double massAtApoapsis = stateAfterBurn1.getMass(); // approximate (coast is ballistic)
     double dt2 =
         Physics.computeBurnDuration(

--- a/src/main/java/com/smousseur/orbitlab/simulation/mission/maneuver/GravityTurnManeuver.java
+++ b/src/main/java/com/smousseur/orbitlab/simulation/mission/maneuver/GravityTurnManeuver.java
@@ -4,6 +4,7 @@ import com.smousseur.orbitlab.simulation.OrekitService;
 import com.smousseur.orbitlab.simulation.Physics;
 import com.smousseur.orbitlab.simulation.mission.attitude.GravityTurnAttitudeProvider;
 import com.smousseur.orbitlab.simulation.mission.stage.ascent.GravityTurnStage;
+import com.smousseur.orbitlab.simulation.mission.vehicle.ActiveStageInfo;
 import com.smousseur.orbitlab.simulation.mission.vehicle.PropulsionSystem;
 import com.smousseur.orbitlab.simulation.mission.vehicle.Vehicle;
 import org.hipparchus.geometry.euclidean.threed.Vector3D;
@@ -24,6 +25,9 @@ import org.orekit.utils.Constants;
  * Encapsulates the gravity turn maneuver configuration logic. Shared between {@link
  * GravityTurnStage} (execution) and {@link
  * com.smousseur.orbitlab.simulation.mission.optimizer.problems.GravityTurnProblem} (optimization).
+ *
+ * <p>Stage resolution is automatic: the active stage and the next stage after jettison are
+ * determined from the vehicle's reference mass via {@link Vehicle#resolveActiveStage(double)}.
  */
 public class GravityTurnManeuver {
 
@@ -33,6 +37,8 @@ public class GravityTurnManeuver {
   private final double pitchKickAngleRad;
   private final double launchAzimuth;
   private final double usedAscensionPropellant;
+  private final ActiveStageInfo activeStage;
+  private final ActiveStageInfo nextStage;
 
   /**
    * Creates a gravity turn maneuver for the given vehicle and launch parameters.
@@ -48,8 +54,9 @@ public class GravityTurnManeuver {
     this.vehicle = vehicle;
     this.pitchKickAngleRad = pitchKickAngleRad;
     this.launchAzimuth = launchAzimuth;
-    this.usedAscensionPropellant =
-        vehicle.getFirstStage().propulsion().massBurnt(ascensionDuration);
+    this.activeStage = vehicle.resolveActiveStage(vehicle.getMass());
+    this.nextStage = vehicle.resolveActiveStage(activeStage.massAfterJettison());
+    this.usedAscensionPropellant = activeStage.propulsion().massBurnt(ascensionDuration);
   }
 
   /**
@@ -75,10 +82,10 @@ public class GravityTurnManeuver {
     double exponent = variables[1];
 
     // Burn1 duration until propellant exhaustion
-    PropulsionSystem prop1 = vehicle.getFirstStage().propulsion();
+    PropulsionSystem prop1 = activeStage.propulsion();
     double massFlowRate1 = prop1.thrust() / (prop1.isp() * Constants.G0_STANDARD_GRAVITY);
     double burn1Duration =
-        (vehicle.getFirstStage().propellantCapacity() - usedAscensionPropellant) / massFlowRate1;
+        (activeStage.propellantCapacity() - usedAscensionPropellant) / massFlowRate1;
 
     // Burn2 duration after jettison until transitionTime
     double burn2Duration = transitionTime - burn1Duration;
@@ -109,15 +116,14 @@ public class GravityTurnManeuver {
    */
   public void configure(
       NumericalPropagator propagator, SpacecraftState kickedState, GravityTurnParams params) {
-    PropulsionSystem propulsion = vehicle.propulsion();
     AbsoluteDate kickDate = kickedState.getDate();
 
     GravityTurnAttitudeProvider attitudeProvider =
         new GravityTurnAttitudeProvider(kickDate, params.transitionTime(), params.exponent());
     propagator.setAttitudeProvider(attitudeProvider);
 
-    // Burn 1
-    PropulsionSystem propulsion1 = vehicle.getFirstStage().propulsion();
+    // Burn 1 — active stage propulsion
+    PropulsionSystem propulsion1 = activeStage.propulsion();
     ConstantThrustManeuver burn1 =
         new ConstantThrustManeuver(
             kickDate.shiftedBy(1.0e-3),
@@ -129,7 +135,8 @@ public class GravityTurnManeuver {
 
     AbsoluteDate jettisonDate =
         kickDate.shiftedBy(1.0e-3).shiftedBy(params.burn1Duration).shiftedBy(1.0e-3);
-    // Jettison
+    // Jettison — mass drops to the reference mass of all stages above
+    double massAfterJettison = activeStage.massAfterJettison();
     DateDetector jettisonDetector =
         new DateDetector(jettisonDate)
             .withHandler(
@@ -143,13 +150,12 @@ public class GravityTurnManeuver {
                   @Override
                   public SpacecraftState resetState(
                       EventDetector detector, SpacecraftState oldState) {
-                    double newMass = vehicle.getMass() - vehicle.getFirstStage().getMass();
-                    return oldState.withMass(newMass);
+                    return oldState.withMass(massAfterJettison);
                   }
                 });
     propagator.addEventDetector(jettisonDetector);
-    // Burn 2
-    PropulsionSystem propulsion2 = vehicle.getSecondStage().propulsion();
+    // Burn 2 — next stage propulsion (after jettison)
+    PropulsionSystem propulsion2 = nextStage.propulsion();
     ConstantThrustManeuver burn2 =
         new ConstantThrustManeuver(
             jettisonDate.shiftedBy(1.0e-3),
@@ -189,9 +195,9 @@ public class GravityTurnManeuver {
    * @return the burn 1 duration in seconds
    */
   public double getBurn1Duration() {
-    PropulsionSystem prop1 = vehicle.getFirstStage().propulsion();
+    PropulsionSystem prop1 = activeStage.propulsion();
     double massFlowRate1 = prop1.thrust() / (prop1.isp() * Constants.G0_STANDARD_GRAVITY);
-    return (vehicle.getFirstStage().propellantCapacity() - usedAscensionPropellant) / massFlowRate1;
+    return (activeStage.propellantCapacity() - usedAscensionPropellant) / massFlowRate1;
   }
 
   /**

--- a/src/main/java/com/smousseur/orbitlab/simulation/mission/maneuver/TransfertTwoManeuver.java
+++ b/src/main/java/com/smousseur/orbitlab/simulation/mission/maneuver/TransfertTwoManeuver.java
@@ -3,6 +3,7 @@ package com.smousseur.orbitlab.simulation.mission.maneuver;
 import com.smousseur.orbitlab.simulation.OrekitService;
 import com.smousseur.orbitlab.simulation.Physics;
 import com.smousseur.orbitlab.simulation.mission.detector.MinAltitudeTracker;
+import com.smousseur.orbitlab.simulation.mission.vehicle.ActiveStageInfo;
 import com.smousseur.orbitlab.simulation.mission.vehicle.PropulsionSystem;
 import com.smousseur.orbitlab.simulation.mission.vehicle.Vehicle;
 import org.apache.logging.log4j.LogManager;
@@ -39,6 +40,9 @@ import org.orekit.utils.Constants;
  *   <li>[2] alpha1 — in-plane thrust angle in TNW frame (rad)
  *   <li>[3] beta1 — out-of-plane thrust angle in TNW frame (rad)
  * </ul>
+ *
+ * <p>The active stage propulsion is resolved automatically from the spacecraft mass via {@link
+ * Vehicle#resolveActiveStage(double)}.
  */
 public class TransfertTwoManeuver {
   private static final Logger logger = LogManager.getLogger(TransfertTwoManeuver.class);
@@ -51,7 +55,7 @@ public class TransfertTwoManeuver {
   /**
    * Creates a two-burn transfer maneuver targeting the specified circular orbit altitude.
    *
-   * @param vehicle the vehicle performing the transfer (second stage propulsion is used)
+   * @param vehicle the vehicle performing the transfer
    * @param targetAltitude the target circular orbit altitude above Earth's surface in meters
    */
   public TransfertTwoManeuver(Vehicle vehicle, double targetAltitude) {
@@ -168,7 +172,8 @@ public class TransfertTwoManeuver {
 
     AbsoluteDate epoch = state.getDate();
     LofOffset attitude = new LofOffset(state.getFrame(), LOFType.TNW);
-    PropulsionSystem propulsion = vehicle.getSecondStage().propulsion();
+    ActiveStageInfo stage = vehicle.resolveActiveStage(state.getMass());
+    PropulsionSystem propulsion = stage.propulsion();
 
     // ── Burn 1: optimized (near apoapsis, quasi-circularizes) ──
     AbsoluteDate burn1Start = epoch.shiftedBy(params.t1);
@@ -224,7 +229,8 @@ public class TransfertTwoManeuver {
     AbsoluteDate burn1End = burn1Start.shiftedBy(params.dt1);
 
     LofOffset attitude = new LofOffset(initialState.getFrame(), LOFType.TNW);
-    PropulsionSystem propulsion = vehicle.getSecondStage().propulsion();
+    ActiveStageInfo stage = vehicle.resolveActiveStage(initialState.getMass());
+    PropulsionSystem propulsion = stage.propulsion();
     Vector3D thrustDir1 = Physics.buildThrustDirectionTNW(params.alpha1, params.beta1);
 
     burn1Propagator.addForceModel(

--- a/src/main/java/com/smousseur/orbitlab/simulation/mission/stage/ConstantThrustStage.java
+++ b/src/main/java/com/smousseur/orbitlab/simulation/mission/stage/ConstantThrustStage.java
@@ -3,8 +3,8 @@ package com.smousseur.orbitlab.simulation.mission.stage;
 import com.smousseur.orbitlab.simulation.OrekitService;
 import com.smousseur.orbitlab.simulation.mission.Mission;
 import com.smousseur.orbitlab.simulation.mission.MissionStage;
+import com.smousseur.orbitlab.simulation.mission.vehicle.ActiveStageInfo;
 import com.smousseur.orbitlab.simulation.mission.vehicle.PropulsionSystem;
-import com.smousseur.orbitlab.simulation.mission.vehicle.Vehicle;
 import org.hipparchus.geometry.euclidean.threed.Vector3D;
 import org.hipparchus.ode.events.Action;
 import org.orekit.attitudes.AttitudeProvider;
@@ -18,9 +18,9 @@ import org.orekit.time.AbsoluteDate;
 import org.orekit.utils.Constants;
 
 /**
- * A mission stage that applies a constant-thrust maneuver along the velocity direction in the
- * TNW (Tangential-Normal-Binormal) local orbital frame. The stage terminates after the specified
- * burn duration. If the duration is set to zero, it is automatically computed from the vehicle's
+ * A mission stage that applies a constant-thrust maneuver along the velocity direction in the TNW
+ * (Tangential-Normal-Binormal) local orbital frame. The stage terminates after the specified burn
+ * duration. If the duration is set to zero, it is automatically computed from the active stage's
  * available propellant and thrust at entry time.
  */
 public class ConstantThrustStage extends MissionStage {
@@ -41,10 +41,11 @@ public class ConstantThrustStage extends MissionStage {
   @Override
   public SpacecraftState enter(SpacecraftState previousState, Mission mission) {
     if (duration == 0) {
-      Vehicle vehicle = mission.getVehicle();
-      PropulsionSystem propulsion = vehicle.propulsion();
+      ActiveStageInfo activeStage =
+          mission.getVehicle().resolveActiveStage(previousState.getMass());
+      PropulsionSystem propulsion = activeStage.propulsion();
       double mDot = propulsion.thrust() / (propulsion.isp() * Constants.G0_STANDARD_GRAVITY);
-      this.duration = vehicle.propellantCapacity() / mDot;
+      this.duration = activeStage.propellantCapacity() / mDot;
     }
     return previousState;
   }
@@ -53,7 +54,9 @@ public class ConstantThrustStage extends MissionStage {
   public void configure(NumericalPropagator propagator, Mission mission) {
     SpacecraftState currentState = mission.getCurrentState();
 
-    PropulsionSystem propulsion = mission.getVehicle().propulsion();
+    ActiveStageInfo activeStage =
+        mission.getVehicle().resolveActiveStage(currentState.getMass());
+    PropulsionSystem propulsion = activeStage.propulsion();
     ConstantThrustManeuver burn =
         new ConstantThrustManeuver(
             currentState.getDate().shiftedBy(1.0e-3),
@@ -88,7 +91,9 @@ public class ConstantThrustStage extends MissionStage {
     NumericalPropagator propagator = OrekitService.get().createSimplePropagator();
     propagator.setInitialState(stateAfterEnter);
 
-    PropulsionSystem propulsion = mission.getVehicle().propulsion();
+    ActiveStageInfo activeStage =
+        mission.getVehicle().resolveActiveStage(stateAfterEnter.getMass());
+    PropulsionSystem propulsion = activeStage.propulsion();
     ConstantThrustManeuver burn =
         new ConstantThrustManeuver(
             stateAfterEnter.getDate().shiftedBy(1.0e-3),

--- a/src/main/java/com/smousseur/orbitlab/simulation/mission/stage/TransfertTwoManeuverStage.java
+++ b/src/main/java/com/smousseur/orbitlab/simulation/mission/stage/TransfertTwoManeuverStage.java
@@ -9,6 +9,7 @@ import com.smousseur.orbitlab.simulation.mission.maneuver.TransfertTwoManeuver.B
 import com.smousseur.orbitlab.simulation.mission.maneuver.TransfertTwoManeuver.ResolvedBurn2;
 import com.smousseur.orbitlab.simulation.mission.optimizer.OptimizationResult;
 import com.smousseur.orbitlab.simulation.mission.optimizer.problems.TransferTwoManeuverProblem;
+import com.smousseur.orbitlab.simulation.mission.vehicle.ActiveStageInfo;
 import org.hipparchus.ode.events.Action;
 import org.orekit.propagation.SpacecraftState;
 import org.orekit.propagation.events.DateDetector;
@@ -71,15 +72,16 @@ public class TransfertTwoManeuverStage extends MissionStage
   @Override
   public TransferTwoManeuverProblem buildProblem(Mission mission) {
     TransfertTwoManeuver maneuver = new TransfertTwoManeuver(mission.getVehicle(), targetAltitude);
-    // Min viable mass after all transfer burns = dry mass of remaining stages (stage 2 + spacecraft)
-    // Vehicle model still holds all stages at this point, so subtract the already-jettisoned stage 1
-    double vehicleMinMass =
-        mission.getVehicle().dryMass() - mission.getVehicle().getFirstStage().dryMass();
+    // Resolve the active stage from the current spacecraft mass (stage 1 is already jettisoned)
+    ActiveStageInfo activeStage =
+        mission.getVehicle().resolveActiveStage(mission.getCurrentState().getMass());
+    // Min viable mass = dry mass of active stage + dry mass of all stages above
+    double vehicleMinMass = activeStage.remainingDryMass();
     return new TransferTwoManeuverProblem(
         maneuver,
         mission.getCurrentState(),
         targetAltitude,
-        mission.getVehicle().getSecondStage().propulsion(),
+        activeStage.propulsion(),
         vehicleMinMass);
   }
 

--- a/src/main/java/com/smousseur/orbitlab/simulation/mission/vehicle/ActiveStageInfo.java
+++ b/src/main/java/com/smousseur/orbitlab/simulation/mission/vehicle/ActiveStageInfo.java
@@ -1,0 +1,61 @@
+package com.smousseur.orbitlab.simulation.mission.vehicle;
+
+/**
+ * Snapshot of the active stage resolved from the current spacecraft mass. Provides all the
+ * information needed by maneuvers and mission stages without explicit stage-index lookups.
+ *
+ * @param stageIndex zero-based index of the active stage in the vehicle stack
+ * @param stage the reference Vehicle representing the active stage
+ * @param massAbove total reference mass (dry + propellant) of all stages above the active one
+ * @param dryMassAbove total dry mass of all stages above the active one
+ */
+public record ActiveStageInfo(
+    int stageIndex, Vehicle stage, double massAbove, double dryMassAbove) {
+
+  /** Returns the propulsion system of the active stage. */
+  public PropulsionSystem propulsion() {
+    return stage.propulsion();
+  }
+
+  /** Returns the dry mass of the active stage. */
+  public double dryMass() {
+    return stage.dryMass();
+  }
+
+  /** Returns the propellant capacity of the active stage. */
+  public double propellantCapacity() {
+    return stage.propellantCapacity();
+  }
+
+  /** Returns the total reference mass (dry + propellant) of the active stage. */
+  public double stageMass() {
+    return stage.getMass();
+  }
+
+  /**
+   * Returns the mass the spacecraft should have immediately after jettisoning the active stage.
+   * This equals the total reference mass of all stages above.
+   */
+  public double massAfterJettison() {
+    return massAbove;
+  }
+
+  /**
+   * Returns the remaining fuel in the active stage given the current spacecraft mass.
+   *
+   * @param currentMass the current total spacecraft mass from SpacecraftState
+   * @return the remaining propellant mass in the active stage
+   */
+  public double remainingFuel(double currentMass) {
+    return currentMass - stage.dryMass() - massAbove;
+  }
+
+  /**
+   * Returns the total dry mass from this stage upward (active stage dry mass + dry mass of all
+   * stages above). This is the minimum possible mass after all propellant in and above this stage
+   * is exhausted.
+   */
+  public double remainingDryMass() {
+    return stage.dryMass() + dryMassAbove;
+  }
+}

--- a/src/main/java/com/smousseur/orbitlab/simulation/mission/vehicle/Vehicle.java
+++ b/src/main/java/com/smousseur/orbitlab/simulation/mission/vehicle/Vehicle.java
@@ -2,8 +2,10 @@ package com.smousseur.orbitlab.simulation.mission.vehicle;
 
 /**
  * Represents a vehicle in the mission simulation. A vehicle has a dry mass, propellant capacity,
- * and a propulsion system. Vehicles can be single-stage or multi-stage (via {@link VehicleStack}),
- * and support stage retrieval and jettison operations.
+ * and a propulsion system. Vehicles can be single-stage or multi-stage (via {@link VehicleStack}).
+ *
+ * <p>The active stage is resolved dynamically via {@link #resolveActiveStage(double)} based on the
+ * current spacecraft mass, eliminating the need for explicit stage-index lookups.
  */
 public interface Vehicle {
   /**
@@ -21,33 +23,11 @@ public interface Vehicle {
   double propellantCapacity();
 
   /**
-   * Returns the first stage of this vehicle. For single-stage vehicles, returns itself.
+   * Returns the propulsion system of this vehicle or its active stage.
    *
-   * @return the first stage vehicle
+   * @return the propulsion system
    */
-  default Vehicle getFirstStage() {
-    return getStage(0);
-  }
-
-  /**
-   * Returns the second stage of this vehicle. For single-stage vehicles, returns itself.
-   *
-   * @return the second stage vehicle
-   */
-  default Vehicle getSecondStage() {
-    return getStage(1);
-  }
-
-  /**
-   * Returns the stage at the given index. For single-stage vehicles, returns itself regardless of
-   * the index.
-   *
-   * @param index the zero-based stage index
-   * @return the vehicle representing the requested stage
-   */
-  default Vehicle getStage(int index) {
-    return this;
-  }
+  PropulsionSystem propulsion();
 
   /**
    * Returns the total mass of this vehicle (dry mass plus propellant).
@@ -59,37 +39,14 @@ public interface Vehicle {
   }
 
   /**
-   * Returns the total dry mass of all stages combined. For stacked vehicles, this excludes the
-   * current stage's propellant but includes all other mass.
+   * Resolves the active stage based on the current spacecraft mass. For single-stage vehicles,
+   * always returns itself. For multi-stage vehicles ({@link VehicleStack}), determines which stage
+   * is active by comparing the current mass against cumulative stage mass thresholds.
    *
-   * @return the full dry mass in kilograms
+   * @param currentMass the current spacecraft mass from SpacecraftState
+   * @return the active stage information
    */
-  default double getFullDryMass() {
-    return dryMass();
-  }
-
-  /**
-   * Returns the propellant mass of the current (first) stage only.
-   *
-   * @return the current stage propellant mass in kilograms
-   */
-  default double getCurrentStagePropellantMass() {
-    return propellantCapacity();
-  }
-
-  /**
-   * Returns the propulsion system of this vehicle or its active stage.
-   *
-   * @return the propulsion system
-   */
-  PropulsionSystem propulsion();
-
-  /**
-   * Returns the dry mass of the first stage only.
-   *
-   * @return the first stage dry mass in kilograms
-   */
-  default double getFirstStageDryMass() {
-    return dryMass();
+  default ActiveStageInfo resolveActiveStage(double currentMass) {
+    return new ActiveStageInfo(0, this, 0, 0);
   }
 }

--- a/src/main/java/com/smousseur/orbitlab/simulation/mission/vehicle/VehicleStack.java
+++ b/src/main/java/com/smousseur/orbitlab/simulation/mission/vehicle/VehicleStack.java
@@ -7,13 +7,9 @@ import java.util.List;
  * the currently active (bottom) stage. Mass and propulsion queries delegate to the constituent
  * vehicles.
  *
- * @param vehicles the ordered list of vehicle stages
+ * @param vehicles the ordered list of vehicle stages (index 0 = bottom stage)
  */
 public record VehicleStack(List<Vehicle> vehicles) implements Vehicle {
-  @Override
-  public Vehicle getStage(int index) {
-    return vehicles.get(index);
-  }
 
   @Override
   public double dryMass() {
@@ -31,22 +27,39 @@ public record VehicleStack(List<Vehicle> vehicles) implements Vehicle {
   }
 
   @Override
-  public double getFullDryMass() {
-    return getMass() - vehicles.getFirst().propellantCapacity();
-  }
-
-  @Override
-  public double getCurrentStagePropellantMass() {
-    return vehicles.getFirst().propellantCapacity();
-  }
-
-  @Override
-  public double getFirstStageDryMass() {
-    return vehicles.getFirst().dryMass();
-  }
-
-  @Override
   public PropulsionSystem propulsion() {
     return vehicles.getFirst().propulsion();
+  }
+
+  /**
+   * Resolves the active stage based on the current spacecraft mass. The active stage is the lowest
+   * (bottom-most) stage whose cumulative mass-above is strictly less than the current mass.
+   *
+   * @param currentMass the current spacecraft mass from SpacecraftState
+   * @return the active stage information
+   */
+  @Override
+  public ActiveStageInfo resolveActiveStage(double currentMass) {
+    int n = vehicles.size();
+    double[] massAbove = new double[n];
+    double[] dryMassAbove = new double[n];
+    double cumulativeMass = 0;
+    double cumulativeDryMass = 0;
+
+    for (int i = n - 1; i >= 0; i--) {
+      massAbove[i] = cumulativeMass;
+      dryMassAbove[i] = cumulativeDryMass;
+      cumulativeMass += vehicles.get(i).getMass();
+      cumulativeDryMass += vehicles.get(i).dryMass();
+    }
+
+    for (int i = 0; i < n; i++) {
+      if (currentMass > massAbove[i]) {
+        return new ActiveStageInfo(i, vehicles.get(i), massAbove[i], dryMassAbove[i]);
+      }
+    }
+    // Fallback: topmost stage
+    int last = n - 1;
+    return new ActiveStageInfo(last, vehicles.get(last), 0, 0);
   }
 }

--- a/src/test/java/com/smousseur/orbitlab/simulation/mission/vehicle/VehicleTest.java
+++ b/src/test/java/com/smousseur/orbitlab/simulation/mission/vehicle/VehicleTest.java
@@ -65,10 +65,12 @@ class VehicleTest {
   }
 
   @Test
-  void launchVehicle_getStage_returnsItself() {
+  void singleVehicle_resolveActiveStage_returnsSelf() {
     LaunchVehicle v = LaunchVehicle.getLauncherStage1Vehicle();
-    assertSame(v, v.getStage(0));
-    assertSame(v, v.getStage(1));
+    ActiveStageInfo info = v.resolveActiveStage(v.getMass());
+    assertEquals(0, info.stageIndex());
+    assertSame(v, info.stage());
+    assertEquals(0, info.massAbove(), 1e-6);
   }
 
   // --- VehicleStack ---
@@ -96,5 +98,96 @@ class VehicleTest {
     VehicleStack stack = new VehicleStack(List.of(s1, s2));
     assertEquals(s1.propulsion().isp(), stack.propulsion().isp(), 1e-6);
     assertEquals(s1.propulsion().thrust(), stack.propulsion().thrust(), 1e-6);
+  }
+
+  // --- resolveActiveStage ---
+
+  @Test
+  void vehicleStack_resolveActiveStage_fullMass_returnsFirstStage() {
+    LaunchVehicle s1 = LaunchVehicle.getLauncherStage1Vehicle();
+    LaunchVehicle s2 = LaunchVehicle.getLauncherStage2Vehicle();
+    Spacecraft sc = Spacecraft.getSpacecraft();
+    VehicleStack stack = new VehicleStack(List.of(s1, s2, sc));
+
+    ActiveStageInfo info = stack.resolveActiveStage(stack.getMass());
+    assertEquals(0, info.stageIndex());
+    assertSame(s1, info.stage());
+    assertEquals(s2.getMass() + sc.getMass(), info.massAbove(), 1e-6);
+    assertEquals(s2.dryMass() + sc.dryMass(), info.dryMassAbove(), 1e-6);
+  }
+
+  @Test
+  void vehicleStack_resolveActiveStage_afterJettison_returnsSecondStage() {
+    LaunchVehicle s1 = LaunchVehicle.getLauncherStage1Vehicle();
+    LaunchVehicle s2 = LaunchVehicle.getLauncherStage2Vehicle();
+    Spacecraft sc = Spacecraft.getSpacecraft();
+    VehicleStack stack = new VehicleStack(List.of(s1, s2, sc));
+
+    // After jettison of stage 1, mass = s2.getMass() + sc.getMass()
+    double massAfterJettison = s2.getMass() + sc.getMass();
+    ActiveStageInfo info = stack.resolveActiveStage(massAfterJettison);
+    assertEquals(1, info.stageIndex());
+    assertSame(s2, info.stage());
+    assertEquals(sc.getMass(), info.massAbove(), 1e-6);
+  }
+
+  @Test
+  void vehicleStack_resolveActiveStage_spacecraftOnly_returnsTopStage() {
+    LaunchVehicle s1 = LaunchVehicle.getLauncherStage1Vehicle();
+    LaunchVehicle s2 = LaunchVehicle.getLauncherStage2Vehicle();
+    Spacecraft sc = Spacecraft.getSpacecraft();
+    VehicleStack stack = new VehicleStack(List.of(s1, s2, sc));
+
+    ActiveStageInfo info = stack.resolveActiveStage(sc.getMass());
+    assertEquals(2, info.stageIndex());
+    assertSame(sc, info.stage());
+    assertEquals(0, info.massAbove(), 1e-6);
+  }
+
+  @Test
+  void vehicleStack_resolveActiveStage_massAfterJettison_equalsReferenceAbove() {
+    LaunchVehicle s1 = LaunchVehicle.getLauncherStage1Vehicle();
+    LaunchVehicle s2 = LaunchVehicle.getLauncherStage2Vehicle();
+    Spacecraft sc = Spacecraft.getSpacecraft();
+    VehicleStack stack = new VehicleStack(List.of(s1, s2, sc));
+
+    ActiveStageInfo stage1 = stack.resolveActiveStage(stack.getMass());
+    assertEquals(s2.getMass() + sc.getMass(), stage1.massAfterJettison(), 1e-6);
+
+    // Chained resolution: resolve next stage from massAfterJettison
+    ActiveStageInfo stage2 = stack.resolveActiveStage(stage1.massAfterJettison());
+    assertEquals(1, stage2.stageIndex());
+    assertEquals(sc.getMass(), stage2.massAfterJettison(), 1e-6);
+  }
+
+  @Test
+  void vehicleStack_resolveActiveStage_remainingFuel() {
+    LaunchVehicle s1 = LaunchVehicle.getLauncherStage1Vehicle();
+    LaunchVehicle s2 = LaunchVehicle.getLauncherStage2Vehicle();
+    Spacecraft sc = Spacecraft.getSpacecraft();
+    VehicleStack stack = new VehicleStack(List.of(s1, s2, sc));
+
+    // At full mass, remaining fuel of stage 1 = propellant capacity of stage 1
+    ActiveStageInfo info = stack.resolveActiveStage(stack.getMass());
+    assertEquals(s1.propellantCapacity(), info.remainingFuel(stack.getMass()), 1e-6);
+
+    // After burning some fuel
+    double partialMass = stack.getMass() - 100_000;
+    ActiveStageInfo info2 = stack.resolveActiveStage(partialMass);
+    assertEquals(s1.propellantCapacity() - 100_000, info2.remainingFuel(partialMass), 1e-6);
+  }
+
+  @Test
+  void vehicleStack_resolveActiveStage_remainingDryMass() {
+    LaunchVehicle s1 = LaunchVehicle.getLauncherStage1Vehicle();
+    LaunchVehicle s2 = LaunchVehicle.getLauncherStage2Vehicle();
+    Spacecraft sc = Spacecraft.getSpacecraft();
+    VehicleStack stack = new VehicleStack(List.of(s1, s2, sc));
+
+    ActiveStageInfo stage1 = stack.resolveActiveStage(stack.getMass());
+    assertEquals(s1.dryMass() + s2.dryMass() + sc.dryMass(), stage1.remainingDryMass(), 1e-6);
+
+    ActiveStageInfo stage2 = stack.resolveActiveStage(stage1.massAfterJettison());
+    assertEquals(s2.dryMass() + sc.dryMass(), stage2.remainingDryMass(), 1e-6);
   }
 }


### PR DESCRIPTION
Replace getFirstStage()/getSecondStage()/getStage(int) with a single resolveActiveStage(double currentMass) method that automatically determines the active stage from the current spacecraft mass. This eliminates coupling between maneuvers and specific stage layouts.

- Add ActiveStageInfo record providing propulsion, mass, jettison info
- Add VehicleStack.resolveActiveStage() with mass-threshold algorithm
- Refactor GravityTurnManeuver, TransfertTwoManeuver, Burn2Resolver, TransfertTwoManeuverStage, and ConstantThrustStage
- Remove getFirstStage, getSecondStage, getStage, getFullDryMass, getCurrentStagePropellantMass, getFirstStageDryMass from Vehicle interface
- Update VehicleTest with resolveActiveStage tests

https://claude.ai/code/session_01HtUonGR2LJHnoyWKhDHcWC