### PR TITLE
Add Mission.reset() for relaunch after optimization

### DIFF
--- a/src/main/java/com/smousseur/orbitlab/simulation/mission/Mission.java
+++ b/src/main/java/com/smousseur/orbitlab/simulation/mission/Mission.java
@@ -303,4 +303,24 @@ public abstract class Mission {
   public void setStatus(MissionStatus status) {
     this.status = status;
   }
+
+  /**
+   * Resets all runtime state so the mission can be re-executed from scratch. Configuration (name,
+   * vehicle, stages, objective, listeners) is preserved. The mission status is set to {@link
+   * MissionStatus#READY}, indicating it has been optimized and is prepared for a new execution
+   * cycle.
+   *
+   * @throws IllegalStateException if the mission has not been optimized yet (status is DRAFT)
+   */
+  public void reset() {
+    if (status == MissionStatus.DRAFT) {
+      throw new IllegalStateException("Cannot reset a mission that has not been optimized");
+    }
+    this.currentStageIndex = -1;
+    this.isStarted = false;
+    this.currentState = null;
+    this.propagator = null;
+    this.lastAltLogDate = null;
+    this.status = MissionStatus.READY;
+  }
 }

--- a/src/test/java/com/smousseur/orbitlab/simulation/mission/optimizer/LEOMissionOptimizationTest.java
+++ b/src/test/java/com/smousseur/orbitlab/simulation/mission/optimizer/LEOMissionOptimizationTest.java
@@ -49,11 +49,7 @@ public class LEOMissionOptimizationTest extends AbstractTrajectoryOptimizerTest 
     mission.setCurrentState(initialState);
     MissionOptimizer optimizer = new MissionOptimizer(mission, 40_000);
     MissionOptimizerResult optimResults = optimizer.optimize();
-    mission =
-        new AbstractTrajectoryOptimizerTest.TestMission(
-            "Gravity Turn", getStages(targetAltitude), getMissionVehicle(), 5.23, -52.77, 0.0, targetAltitude);
-    initialState = mission.getInitialState(epoch);
-    mission.setCurrentState(initialState);
+    mission.reset();
     MissionPlayer player = new MissionPlayer(mission);
     player.play(optimResults, epoch);
     PropagationResults results = propagateMission(mission, "Coasting", epoch);


### PR DESCRIPTION
Instead of creating a new Mission instance for replay after optimization,
reset the same instance's runtime state (currentStageIndex, isStarted,
currentState, propagator, lastAltLogDate) and set status to READY.
This matches the real application workflow: optimize → reset → play.

Updated LEO test to use mission.reset() instead of a second TestMission.

https://claude.ai/code/session_01MDYWBcK1mk4Pj6j7SCRqMS