### PR TITLE
Fix spacecraft display: attach 3D model node to scene graph and use n…

### DIFF
--- a/src/main/java/com/smousseur/orbitlab/OrbitLabApplication.java
+++ b/src/main/java/com/smousseur/orbitlab/OrbitLabApplication.java
@@ -112,6 +112,7 @@ public class OrbitLabApplication extends SimpleApplication {
     farViewport.attachScene(sceneGraph.getFarRoot());
 
     Camera nearCam = farCam.clone();
+    applicationContext.setNearCamera(nearCam);
     ViewPort nearViewport = renderManager.createPostView("NearView", nearCam);
 
     nearViewport.setClearFlags(false, true, false); // don't clear color, DO clear depth

--- a/src/main/java/com/smousseur/orbitlab/app/ApplicationContext.java
+++ b/src/main/java/com/smousseur/orbitlab/app/ApplicationContext.java
@@ -1,5 +1,6 @@
 package com.smousseur.orbitlab.app;
 
+import com.jme3.renderer.Camera;
 import com.jme3.scene.Node;
 import com.jme3.scene.Spatial;
 import com.smousseur.orbitlab.app.view.FocusView;
@@ -34,6 +35,7 @@ public class ApplicationContext {
 
   private final FocusView focusView;
   private final MissionContext missionContext;
+  private Camera nearCamera;
 
   /**
    * Creates a new application context and attaches the scene and GUI graphs to the provided JME3
@@ -172,5 +174,23 @@ public class ApplicationContext {
    */
   public MissionContext missionContext() {
     return missionContext;
+  }
+
+  /**
+   * Returns the near viewport camera (planet/spacecraft scale).
+   *
+   * @return the near camera
+   */
+  public Camera nearCamera() {
+    return nearCamera;
+  }
+
+  /**
+   * Sets the near viewport camera.
+   *
+   * @param nearCamera the near viewport camera
+   */
+  public void setNearCamera(Camera nearCamera) {
+    this.nearCamera = nearCamera;
   }
 }

--- a/src/main/java/com/smousseur/orbitlab/states/mission/MissionOrchestratorAppState.java
+++ b/src/main/java/com/smousseur/orbitlab/states/mission/MissionOrchestratorAppState.java
@@ -77,7 +77,8 @@ public final class MissionOrchestratorAppState extends BaseAppState {
     pollMissionActions();
 
     MissionContext missionContext = context.missionContext();
-    Camera cam = getApplication().getCamera();
+    // Use the near camera: spacecraft lives in the near view (km scale), not the far view (solar scale)
+    Camera cam = context.nearCamera();
 
     // Track which missions are still in the context
     Set<String> activeMissionNames = new HashSet<>();

--- a/src/main/java/com/smousseur/orbitlab/states/mission/MissionRenderer.java
+++ b/src/main/java/com/smousseur/orbitlab/states/mission/MissionRenderer.java
@@ -86,9 +86,12 @@ public final class MissionRenderer {
     presenter = new SpacecraftPresenter(config.id(), view);
     presenter.setVisible(true);
 
-    Node nearBodiesNode = context.sceneGraph().nearBodiesNode();
-    Spatial anchor = view.spatial();
-    nearBodiesNode.attachChild(anchor);
+    // Attach anchor3d (3D model) as child of farAnchor so they move together in the near view.
+    // Unlike planets (where farAnchor is in far view and anchor3d in near view), the spacecraft
+    // lives entirely in the near view, so both nodes share the same coordinate system.
+    Node anchor = (Node) view.spatial();
+    anchor.attachChild(view.nearSpatial());
+    context.sceneGraph().nearBodiesNode().attachChild(anchor);
 
     // Load 3D model asynchronously
     ExecutorService assetExecutor = AssetFactory.get().assetLoadingExecutor();


### PR DESCRIPTION
…ear camera for LOD/billboard

Three bugs prevented the spacecraft from rendering in the LEO mission:
1. anchor3d (3D model node) was never attached to the scene graph - now attached as child of farAnchor
2. Far camera (solar scale) was used for LOD distance and billboard projection instead of near camera (km scale)
3. Near camera now exposed via ApplicationContext for spacecraft rendering

https://claude.ai/code/session_01QwyZHXDxL7DoNgvfvYak55