### PR TITLE
Fix trajectory date inconsistency by introducing scheduledDate on Mis…

### DIFF
--- a/src/main/java/com/smousseur/orbitlab/simulation/mission/MissionEntry.java
+++ b/src/main/java/com/smousseur/orbitlab/simulation/mission/MissionEntry.java
@@ -3,6 +3,7 @@ package com.smousseur.orbitlab.simulation.mission;
 import com.smousseur.orbitlab.simulation.mission.runtime.MissionOptimizerResult;
 import java.util.Objects;
 import java.util.Optional;
+import org.orekit.time.AbsoluteDate;
 
 /**
  * Groups a {@link Mission} with its optimization result and runtime preparation state. This is a
@@ -15,6 +16,7 @@ public final class MissionEntry {
   private final Mission mission;
   private volatile MissionOptimizerResult optimizerResult;
   private volatile boolean playerPrepared;
+  private volatile AbsoluteDate scheduledDate;
 
   /**
    * Creates a new mission entry for the given mission.
@@ -69,5 +71,24 @@ public final class MissionEntry {
    */
   public void setPlayerPrepared(boolean prepared) {
     this.playerPrepared = prepared;
+  }
+
+  /**
+   * Sets the planned launch date for this mission. If not set before optimization, it will be
+   * defaulted to the current simulation clock time at the moment optimization is submitted.
+   *
+   * @param date the planned launch date
+   */
+  public void setScheduledDate(AbsoluteDate date) {
+    this.scheduledDate = date;
+  }
+
+  /**
+   * Returns the planned launch date, if set.
+   *
+   * @return an optional containing the scheduled date, or empty if not yet defined
+   */
+  public Optional<AbsoluteDate> getScheduledDate() {
+    return Optional.ofNullable(scheduledDate);
   }
 }

--- a/src/main/java/com/smousseur/orbitlab/states/mission/MissionOrchestratorAppState.java
+++ b/src/main/java/com/smousseur/orbitlab/states/mission/MissionOrchestratorAppState.java
@@ -160,8 +160,9 @@ public final class MissionOrchestratorAppState extends BaseAppState {
         () -> {
           try {
             logger.info("Starting optimization for mission '{}'", mission.getName());
-            AbsoluteDate now = context.clock().now();
-            SpacecraftState initialState = mission.getInitialState(now);
+            AbsoluteDate launchDate = entry.getScheduledDate().orElseGet(context.clock()::now);
+            entry.setScheduledDate(launchDate);
+            SpacecraftState initialState = mission.getInitialState(launchDate);
             mission.setCurrentState(initialState);
             MissionOptimizer optimizer = new MissionOptimizer(mission);
             MissionOptimizerResult result = optimizer.optimize();
@@ -187,8 +188,16 @@ public final class MissionOrchestratorAppState extends BaseAppState {
       throw new IllegalStateException(
           "Mission '" + entry.mission().getName() + "' is not ready to start");
     }
-    entry.mission().start(context.clock().now());
-    logger.info("Mission '{}' started", entry.mission().getName());
+    AbsoluteDate launchDate =
+        entry
+            .getScheduledDate()
+            .orElseThrow(
+                () ->
+                    new IllegalStateException(
+                        "Mission '" + entry.mission().getName() + "' has no scheduled date"));
+    context.clock().seek(launchDate);
+    entry.mission().start(launchDate);
+    logger.info("Mission '{}' started at {}", entry.mission().getName(), launchDate);
   }
 
   private void prepareMission(MissionEntry entry) {


### PR DESCRIPTION
…sionEntry

Add a scheduledDate field to MissionEntry that represents the planned launch date for a mission. This date defaults to clock.now() at optimization time if not set explicitly, and is locked in so both optimization and mission start use the same epoch.

At mission start, the simulation clock is seeked to the scheduled date before calling mission.start(), ensuring the pre-calculated trajectory (which was optimized for that specific date/Earth-rotation geometry) is always coherent with the running simulation. Previously, starting a mission at a different clock time than optimization caused physical inconsistency and visible state jumps at stage transitions (stageEntryState date mismatch).

https://claude.ai/code/session_01LDgtgMPfcfe3x6HijCrJKd