### PR TITLE
Fix mission status ownership and telemetry widget trigger condition

### DIFF
--- a/src/main/java/com/smousseur/orbitlab/states/mission/MissionOrchestratorAppState.java
+++ b/src/main/java/com/smousseur/orbitlab/states/mission/MissionOrchestratorAppState.java
@@ -167,7 +167,6 @@ public final class MissionOrchestratorAppState extends BaseAppState {
             MissionOptimizer optimizer = new MissionOptimizer(mission);
             MissionOptimizerResult result = optimizer.optimize();
             entry.setOptimizerResult(result);
-            mission.setStatus(MissionStatus.READY);
             logger.info("Optimization completed for mission '{}'", mission.getName());
           } catch (Exception e) {
             mission.setStatus(MissionStatus.FAILED);

--- a/src/main/java/com/smousseur/orbitlab/states/mission/TelemetryWidgetAppState.java
+++ b/src/main/java/com/smousseur/orbitlab/states/mission/TelemetryWidgetAppState.java
@@ -4,6 +4,7 @@ import com.jme3.app.Application;
 import com.jme3.app.state.BaseAppState;
 import com.smousseur.orbitlab.app.ApplicationContext;
 import com.smousseur.orbitlab.simulation.mission.Mission;
+import com.smousseur.orbitlab.simulation.mission.MissionStatus;
 import com.smousseur.orbitlab.ui.telemetry.TelemetryWidget;
 import java.util.Optional;
 
@@ -40,7 +41,7 @@ public final class TelemetryWidgetAppState extends BaseAppState {
     Optional<Mission> ongoing =
         context.missionContext().getMissions().stream()
             .map(entry -> entry.mission())
-            .filter(Mission::isOnGoing)
+            .filter(m -> m.getStatus() == MissionStatus.RUNNING)
             .findFirst();
 
     if (ongoing.isPresent()) {


### PR DESCRIPTION
- MissionOptimizer is the sole owner of the READY transition after
  successful optimization; remove the redundant setStatus(READY) call
  in MissionOrchestratorAppState that duplicated it
- TelemetryWidgetAppState now filters by status == RUNNING instead of
  isOnGoing(), aligning the HUD visibility with the authoritative status
  field and ensuring it only appears during an actual launch, never
  during optimization

https://claude.ai/code/session_01Jr6VxdDpiyAhKkTt41sQWv