### PR TITLE
Define tri-state visibility behavior based on mission time range

### DIFF
--- a/src/main/java/com/smousseur/orbitlab/simulation/mission/Mission.java
+++ b/src/main/java/com/smousseur/orbitlab/simulation/mission/Mission.java
@@ -40,6 +40,7 @@ public abstract class Mission {
   private NumericalPropagator propagator;
 
   private AbsoluteDate initialDate;
+  private AbsoluteDate endDate;
 
   private MissionStatus status = MissionStatus.DRAFT;
   private AbsoluteDate lastAltLogDate = null;
@@ -141,6 +142,7 @@ public abstract class Mission {
     currentStageIndex++;
     if (isFinished()) {
       this.currentState = stateAtEvent;
+      this.endDate = stateAtEvent.getDate();
       this.status = MissionStatus.COMPLETED;
       return;
     }
@@ -251,6 +253,16 @@ public abstract class Mission {
   }
 
   /**
+   * Returns the date at which the mission completed (all stages finished). Returns {@code null} if
+   * the mission has not yet completed.
+   *
+   * @return the mission end date, or {@code null}
+   */
+  public AbsoluteDate getEndDate() {
+    return endDate;
+  }
+
+  /**
    * Replaces the current spacecraft state. Used to inject externally computed states such as
    * parking orbit states.
    *
@@ -321,6 +333,7 @@ public abstract class Mission {
     this.currentState = null;
     this.propagator = null;
     this.lastAltLogDate = null;
+    this.endDate = null;
     this.status = MissionStatus.READY;
   }
 }

--- a/src/main/java/com/smousseur/orbitlab/states/mission/MissionOrchestratorAppState.java
+++ b/src/main/java/com/smousseur/orbitlab/states/mission/MissionOrchestratorAppState.java
@@ -104,7 +104,10 @@ public final class MissionOrchestratorAppState extends BaseAppState {
           }
         }
         case COMPLETED -> {
-          // Renderer stays visible but no propagation
+          MissionRenderer renderer = renderers.get(name);
+          if (renderer != null) {
+            renderer.update(tpf, cam);
+          }
         }
       }
     }

--- a/src/main/java/com/smousseur/orbitlab/states/mission/MissionRenderer.java
+++ b/src/main/java/com/smousseur/orbitlab/states/mission/MissionRenderer.java
@@ -113,7 +113,30 @@ public final class MissionRenderer {
    */
   public void update(float tpf, Camera cam) {
     Mission mission = entry.mission();
+    AbsoluteDate now = context.clock().now();
+    AbsoluteDate missionStart = mission.getInitialDate();
+    AbsoluteDate missionEnd = mission.getEndDate();
 
+    // Before mission start: hide everything, no propagation
+    if (missionStart != null && now.compareTo(missionStart) < 0) {
+      view.setVisible(false);
+      trajectoryRenderer.setVisible(false);
+      return;
+    }
+
+    // After mission end: show trajectory + spacecraft frozen at final position, no propagation
+    if (missionEnd != null && now.compareTo(missionEnd) > 0) {
+      boolean isPlanetMode = context.focusView().getMode() == ViewMode.PLANET;
+      view.setVisible(isPlanetMode);
+      trajectoryRenderer.setVisible(true);
+      if (isPlanetMode) {
+        view.updateScreen(cam);
+      }
+      trajectoryRenderer.update();
+      return;
+    }
+
+    // Within mission range: normal propagation
     if (!mission.isOnGoing()) {
       return;
     }
@@ -125,8 +148,6 @@ public final class MissionRenderer {
     }
     view.setVisible(true);
 
-    SimulationClock clock = context.clock();
-    AbsoluteDate now = clock.now();
     mission.update(now);
 
     SpacecraftState state = mission.getCurrentState();

--- a/src/main/java/com/smousseur/orbitlab/states/mission/MissionTrajectoryRenderer.java
+++ b/src/main/java/com/smousseur/orbitlab/states/mission/MissionTrajectoryRenderer.java
@@ -108,6 +108,20 @@ public final class MissionTrajectoryRenderer {
     vb.setUpdateNeeded();
   }
 
+  /**
+   * Shows or hides the trajectory line geometry.
+   *
+   * @param visible {@code true} to show, {@code false} to hide
+   */
+  public void setVisible(boolean visible) {
+    if (lineGeometry != null) {
+      lineGeometry.setCullHint(
+          visible
+              ? com.jme3.scene.Spatial.CullHint.Inherit
+              : com.jme3.scene.Spatial.CullHint.Always);
+    }
+  }
+
   /** Detaches the trajectory geometry from the scene. */
   public void cleanup() {
     if (lineGeometry != null) {


### PR DESCRIPTION
When the simulation clock is outside the mission's temporal bounds,
the renderer now hides or freezes display accordingly:
- before missionStart: spacecraft and trajectory both hidden
- within [missionStart, missionEnd]: normal propagation and display
- after missionEnd: trajectory and spacecraft frozen at final position

Mission.java captures the end date when all stages complete.
MissionTrajectoryRenderer gains setVisible() via CullHint.
MissionRenderer.update() implements the tri-state logic.
MissionOrchestratorAppState invokes the renderer in COMPLETED state
so the time-based visibility is applied each frame.

https://claude.ai/code/session_01AYpgAA94K13gFBgiVXYEU4