### PR TITLE
Align spacecraft 3D model with velocity vector

### DIFF
--- a/src/main/java/com/smousseur/orbitlab/engine/scene/spacecraft/SpacecraftPresenter.java
+++ b/src/main/java/com/smousseur/orbitlab/engine/scene/spacecraft/SpacecraftPresenter.java
@@ -6,6 +6,7 @@ import com.smousseur.orbitlab.app.view.RenderTransform;
 import com.smousseur.orbitlab.engine.scene.body.BodyView;
 import com.smousseur.orbitlab.engine.view.JmeVectorAdapter;
 import java.util.Objects;
+import org.hipparchus.geometry.euclidean.threed.Rotation;
 import org.hipparchus.geometry.euclidean.threed.Vector3D;
 
 /**
@@ -34,19 +35,20 @@ public record SpacecraftPresenter(String id, BodyView view) {
   }
 
   /**
-   * Updates the spacecraft's position in the view. The position is provided in GCRF meters
-   * (geocentric, Earth at origin). Since GCRF is already geocentric, no target subtraction is
-   * needed — only scaling to render units and ICRF-to-JME axis conversion are applied.
+   * Updates the spacecraft's position and orientation in the view. The position is provided in GCRF
+   * meters (geocentric, Earth at origin). The rotation is expressed in GCRF (same axes as ICRF) and
+   * represents the GCRF-to-body transformation, matching the convention used for planet ephemerides.
    *
    * @param positionGcrfMeters the spacecraft position in GCRF frame, in meters
+   * @param rotationGcrf rotation from GCRF to spacecraft body frame (body +X = prograde)
    * @param ctx the render context defining the scale (typically Planet with 1 unit = 1 km)
    */
-  public void updatePose(Vector3D positionGcrfMeters, RenderContext ctx) {
+  public void updatePose(Vector3D positionGcrfMeters, Rotation rotationGcrf, RenderContext ctx) {
     // GCRF positions are already geocentric (Earth = origin), same axis orientation as ICRF.
     // We only need to scale (meters -> render units) and convert axes (ICRF -> JME Y-up).
     Vector3D scaled = RenderTransform.scaleMetersToUnits(positionGcrfMeters, ctx);
     Vector3D jme = ctx.axisConvention().icrfToJme(scaled);
-    Vector3f p = JmeVectorAdapter.toVector3f(jme);
-    view.setPositionWorld(p);
+    view.setPositionWorld(JmeVectorAdapter.toVector3f(jme));
+    view.setRotationWorld(RenderTransform.toRenderQuaternion(rotationGcrf));
   }
 }

--- a/src/main/java/com/smousseur/orbitlab/states/mission/MissionRenderer.java
+++ b/src/main/java/com/smousseur/orbitlab/states/mission/MissionRenderer.java
@@ -14,14 +14,17 @@ import com.smousseur.orbitlab.engine.scene.body.BodyRenderConfig;
 import com.smousseur.orbitlab.engine.scene.body.LodView;
 import com.smousseur.orbitlab.engine.scene.body.lod.Model3dView;
 import com.smousseur.orbitlab.engine.scene.spacecraft.SpacecraftPresenter;
+import com.smousseur.orbitlab.simulation.ephemeris.EphemerisInterpolator;
 import com.smousseur.orbitlab.simulation.mission.Mission;
 import com.smousseur.orbitlab.simulation.mission.MissionEntry;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
+import org.hipparchus.geometry.euclidean.threed.Rotation;
 import org.hipparchus.geometry.euclidean.threed.Vector3D;
 import org.orekit.propagation.SpacecraftState;
 import org.orekit.time.AbsoluteDate;
+import org.orekit.utils.PVCoordinates;
 
 /**
  * Encapsulates all rendering for a single mission: spacecraft display (SpacecraftPresenter +
@@ -43,6 +46,12 @@ public final class MissionRenderer {
   private SpacecraftPresenter presenter;
   private LodView view;
   private MissionTrajectoryRenderer trajectoryRenderer;
+
+  // Two-sample SLERP buffer for smooth attitude interpolation between propagation steps
+  private AbsoluteDate prevSampleDate;
+  private Rotation prevSampleRot;
+  private AbsoluteDate lastSampleDate;
+  private Rotation lastSampleRot;
 
   /**
    * Creates a new mission renderer.
@@ -130,6 +139,10 @@ public final class MissionRenderer {
       view.setVisible(isPlanetMode);
       trajectoryRenderer.setVisible(true);
       if (isPlanetMode) {
+        if (lastSampleRot != null) {
+          view.setRotationWorld(
+              com.smousseur.orbitlab.app.view.RenderTransform.toRenderQuaternion(lastSampleRot));
+        }
         view.updateScreen(cam);
       }
       trajectoryRenderer.update();
@@ -156,11 +169,39 @@ public final class MissionRenderer {
     }
 
     Vector3D posGcrf = state.getPosition();
-    presenter.updatePose(posGcrf, renderContext);
+    Rotation rot = velocityAlignedRotation(state.getPVCoordinates());
+
+    // Shift the two-sample buffer
+    prevSampleDate = lastSampleDate;
+    prevSampleRot = lastSampleRot;
+    lastSampleDate = state.getDate();
+    lastSampleRot = rot;
+
+    // SLERP between the two most recent samples at the exact clock time
+    Rotation interpRot = rot;
+    if (prevSampleDate != null && !prevSampleDate.equals(lastSampleDate)) {
+      double dt = lastSampleDate.durationFrom(prevSampleDate);
+      double dn = now.durationFrom(prevSampleDate);
+      double tau = Math.max(0.0, Math.min(1.0, dn / dt));
+      interpRot = EphemerisInterpolator.slerp(prevSampleRot, lastSampleRot, tau);
+    }
+
+    presenter.updatePose(posGcrf, interpRot, renderContext);
     view.updateScreen(cam);
 
     trajectoryRenderer.addPosition(posGcrf);
     trajectoryRenderer.update();
+  }
+
+  /**
+   * Computes a velocity-aligned rotation (GCRF→body) where body +X points along the prograde
+   * (velocity) direction and body +Z points along the orbit normal (vel × pos).
+   */
+  private static Rotation velocityAlignedRotation(PVCoordinates pv) {
+    Vector3D vel = pv.getVelocity();
+    Vector3D pos = pv.getPosition();
+    Vector3D orbitNormal = vel.crossProduct(pos);
+    return new Rotation(vel, orbitNormal, Vector3D.PLUS_I, Vector3D.PLUS_K);
   }
 
   /** Detaches all visual elements from the scene. */


### PR DESCRIPTION
- SpacecraftPresenter.updatePose() now accepts a Hipparchus Rotation
  (GCRF→body) alongside position, and applies it via the existing
  RenderTransform.toRenderQuaternion() path (same ICRF→JME axis
  sandwiching + mesh correction used for planets)
- MissionRenderer computes a velocity-aligned rotation each frame from
  SpacecraftState.getPVCoordinates(): body +X = prograde direction,
  body +Z = orbit normal (vel × pos)
- A two-sample SLERP buffer (EphemerisInterpolator.slerp) smooths the
  rotation at the exact clock time between consecutive propagation steps,
  mirroring the planet ephemeris interpolation pattern
- Final attitude is preserved and re-applied when the mission ends so
  the frozen spacecraft keeps its last orientation

https://claude.ai/code/session_01AgXwkupm6LFgpFuJkujVkT