### PR TITLE
Translate French comments, remove dead code, fix bug, and add unit tests

### DIFF
--- a/src/main/java/com/smousseur/orbitlab/app/SimulationClock.java
+++ b/src/main/java/com/smousseur/orbitlab/app/SimulationClock.java
@@ -241,9 +241,4 @@ public final class SimulationClock {
       l.accept(event);
     }
   }
-
-  // For debugging/tests
-  List<Consumer<ClockEvent>> listenersSnapshot() {
-    return List.copyOf(listeners);
-  }
 }

--- a/src/main/java/com/smousseur/orbitlab/simulation/mission/detector/MinAltitudeTracker.java
+++ b/src/main/java/com/smousseur/orbitlab/simulation/mission/detector/MinAltitudeTracker.java
@@ -18,7 +18,7 @@ public class MinAltitudeTracker extends AbstractDetector<MinAltitudeTracker> {
   private final double maxAltitudeThreshold;
   private final AbsoluteDate activeFrom;
   private double minAltitude = Double.MAX_VALUE;
-  private double maxAltitude = Double.MIN_VALUE;
+  private double maxAltitude = Double.NEGATIVE_INFINITY;
 
   /**
    * Creates a tracker that records altitude extremes, active from the start of propagation.

--- a/src/main/java/com/smousseur/orbitlab/states/fx/LightningAppState.java
+++ b/src/main/java/com/smousseur/orbitlab/states/fx/LightningAppState.java
@@ -36,7 +36,7 @@ public class LightningAppState extends BaseAppState {
   protected void initialize(Application app) {
     rootNode = context.sceneGraph().getRootNode();
     ambientLight = new AmbientLight();
-    ambientLight.setColor(ColorRGBA.White.mult(0.3f)); // intensité de la lumière
+    ambientLight.setColor(ColorRGBA.White.mult(0.3f)); // light intensity
 
     sunLight = new DirectionalLight();
     sunLight.setColor(ColorRGBA.White.mult(1.2f));

--- a/src/main/java/com/smousseur/orbitlab/tools/ephemerisgen/EphemerisDatasetGenerator.java
+++ b/src/main/java/com/smousseur/orbitlab/tools/ephemerisgen/EphemerisDatasetGenerator.java
@@ -55,8 +55,8 @@ public final class EphemerisDatasetGenerator {
 
     TimeScale tai = TimeScalesFactory.getTAI();
 
-    // T_START (origine des offsets)
-    // Plage effective générée (clamp Orekit, end exclusive)
+    // T_START (offset origin)
+    // Effective generated range (Orekit clamp, end exclusive)
     AbsoluteDate tStart = new AbsoluteDate(1990, 1, 1, 0, 0, 0.0, tai);
     AbsoluteDate tEndExclusive = new AbsoluteDate(2100, 12, 31, 0, 0, 0.0, tai);
 

--- a/src/test/java/com/smousseur/orbitlab/simulation/mission/optimizer/OptimizationResultTest.java
+++ b/src/test/java/com/smousseur/orbitlab/simulation/mission/optimizer/OptimizationResultTest.java
@@ -1,0 +1,57 @@
+package com.smousseur.orbitlab.simulation.mission.optimizer;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class OptimizationResultTest {
+
+  @Test
+  void fourArgConstructor_storesCopy_mutatingOriginalDoesNotAffectResult() {
+    double[] vars = {1.0, 2.0, 3.0};
+    OptimizationResult result = new OptimizationResult(vars, 0.5, null, 100);
+
+    vars[0] = 999.0; // mutate original after construction
+
+    assertEquals(1.0, result.bestVariables()[0], 1e-12,
+        "Constructor should have cloned the array; mutation of original must not affect result");
+  }
+
+  @Test
+  void bestVariables_returnsDefensiveCopy_mutatingReturnedArrayDoesNotAffectResult() {
+    OptimizationResult result = new OptimizationResult(new double[]{1.0, 2.0}, 0.5, null, 10);
+
+    double[] copy1 = result.bestVariables();
+    copy1[0] = 999.0; // mutate the returned clone
+
+    assertEquals(1.0, result.bestVariables()[0], 1e-12,
+        "bestVariables() should return a fresh clone each time");
+  }
+
+  @Test
+  void fourArgConstructor_stageEntryState_isNull() {
+    OptimizationResult result = new OptimizationResult(new double[]{0.0}, 1.0, null, 5);
+    assertNull(result.stageEntryState());
+  }
+
+  @Test
+  void fourArgConstructor_fieldsMatchInputs() {
+    double[] vars = {4.0, 5.0};
+    OptimizationResult result = new OptimizationResult(vars, 3.14, null, 42);
+
+    assertArrayEquals(vars, result.bestVariables(), 1e-12);
+    assertEquals(3.14, result.bestCost(), 1e-12);
+    assertEquals(42, result.evaluations());
+  }
+
+  @Test
+  void consecutiveCalls_bestVariables_returnIndependentCopies() {
+    OptimizationResult result = new OptimizationResult(new double[]{7.0, 8.0}, 0.0, null, 1);
+
+    double[] a = result.bestVariables();
+    double[] b = result.bestVariables();
+
+    assertNotSame(a, b, "Each call to bestVariables() must return a distinct array instance");
+    assertArrayEquals(a, b, 1e-12);
+  }
+}

--- a/src/test/java/com/smousseur/orbitlab/simulation/orbit/OrbitPathTest.java
+++ b/src/test/java/com/smousseur/orbitlab/simulation/orbit/OrbitPathTest.java
@@ -1,0 +1,102 @@
+package com.smousseur.orbitlab.simulation.orbit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.smousseur.orbitlab.core.SolarSystemBody;
+import java.util.List;
+import org.hipparchus.geometry.euclidean.threed.Vector3D;
+import org.junit.jupiter.api.Test;
+import org.orekit.time.AbsoluteDate;
+
+class OrbitPathTest {
+
+  private static final AbsoluteDate T0 = AbsoluteDate.J2000_EPOCH;
+  private static final AbsoluteDate T1 = T0.shiftedBy(3600.0);
+
+  @Test
+  void validConstruction_succeeds() {
+    List<Vector3D> positions = List.of(Vector3D.ZERO, Vector3D.PLUS_I);
+    OrbitPath path = new OrbitPath(SolarSystemBody.EARTH, T0, T1, 100.0, positions);
+    assertEquals(SolarSystemBody.EARTH, path.body());
+    assertEquals(T0, path.start());
+    assertEquals(T1, path.end());
+    assertEquals(100.0, path.stepSeconds(), 1e-12);
+    assertSame(positions, path.positionsHelioMeters());
+  }
+
+  @Test
+  void nullBody_throwsNullPointerException() {
+    assertThrows(
+        NullPointerException.class,
+        () -> new OrbitPath(null, T0, T1, 100.0, List.of(Vector3D.ZERO, Vector3D.PLUS_I)));
+  }
+
+  @Test
+  void nullStart_throwsNullPointerException() {
+    assertThrows(
+        NullPointerException.class,
+        () ->
+            new OrbitPath(
+                SolarSystemBody.EARTH, null, T1, 100.0, List.of(Vector3D.ZERO, Vector3D.PLUS_I)));
+  }
+
+  @Test
+  void nullEnd_throwsNullPointerException() {
+    assertThrows(
+        NullPointerException.class,
+        () ->
+            new OrbitPath(
+                SolarSystemBody.EARTH, T0, null, 100.0, List.of(Vector3D.ZERO, Vector3D.PLUS_I)));
+  }
+
+  @Test
+  void nullPositions_throwsNullPointerException() {
+    assertThrows(
+        NullPointerException.class,
+        () -> new OrbitPath(SolarSystemBody.EARTH, T0, T1, 100.0, null));
+  }
+
+  @Test
+  void zeroStepSeconds_throwsIllegalArgumentException() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new OrbitPath(
+                SolarSystemBody.EARTH, T0, T1, 0.0, List.of(Vector3D.ZERO, Vector3D.PLUS_I)));
+  }
+
+  @Test
+  void negativeStepSeconds_throwsIllegalArgumentException() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new OrbitPath(
+                SolarSystemBody.EARTH, T0, T1, -1.0, List.of(Vector3D.ZERO, Vector3D.PLUS_I)));
+  }
+
+  @Test
+  void nanStepSeconds_throwsIllegalArgumentException() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new OrbitPath(
+                SolarSystemBody.EARTH,
+                T0,
+                T1,
+                Double.NaN,
+                List.of(Vector3D.ZERO, Vector3D.PLUS_I)));
+  }
+
+  @Test
+  void infiniteStepSeconds_throwsIllegalArgumentException() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new OrbitPath(
+                SolarSystemBody.EARTH,
+                T0,
+                T1,
+                Double.POSITIVE_INFINITY,
+                List.of(Vector3D.ZERO, Vector3D.PLUS_I)));
+  }
+}

--- a/src/test/java/com/smousseur/orbitlab/simulation/orbit/OrbitSnapshotTest.java
+++ b/src/test/java/com/smousseur/orbitlab/simulation/orbit/OrbitSnapshotTest.java
@@ -1,0 +1,128 @@
+package com.smousseur.orbitlab.simulation.orbit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.smousseur.orbitlab.core.SolarSystemBody;
+import org.hipparchus.geometry.euclidean.threed.Vector3D;
+import org.junit.jupiter.api.Test;
+import org.orekit.time.AbsoluteDate;
+
+class OrbitSnapshotTest {
+
+  private static final AbsoluteDate CENTER = AbsoluteDate.J2000_EPOCH;
+  private static final Vector3D[] TWO_POSITIONS = {Vector3D.ZERO, Vector3D.PLUS_I};
+
+  @Test
+  void validConstruction_succeeds() {
+    OrbitSnapshot snap =
+        new OrbitSnapshot(SolarSystemBody.EARTH, CENTER, 86400.0, 100.0, TWO_POSITIONS, 0);
+    assertEquals(SolarSystemBody.EARTH, snap.body());
+    assertEquals(CENTER, snap.centerDate());
+    assertEquals(86400.0, snap.periodSeconds(), 1e-12);
+    assertEquals(100.0, snap.stepSeconds(), 1e-12);
+    assertEquals(0, snap.version());
+  }
+
+  @Test
+  void nullBody_throwsNullPointerException() {
+    assertThrows(
+        NullPointerException.class,
+        () -> new OrbitSnapshot(null, CENTER, 86400.0, 100.0, TWO_POSITIONS, 0));
+  }
+
+  @Test
+  void nullCenterDate_throwsNullPointerException() {
+    assertThrows(
+        NullPointerException.class,
+        () -> new OrbitSnapshot(SolarSystemBody.EARTH, null, 86400.0, 100.0, TWO_POSITIONS, 0));
+  }
+
+  @Test
+  void nullPositions_throwsNullPointerException() {
+    assertThrows(
+        NullPointerException.class,
+        () -> new OrbitSnapshot(SolarSystemBody.EARTH, CENTER, 86400.0, 100.0, null, 0));
+  }
+
+  @Test
+  void zeroPeriodSeconds_throwsIllegalArgumentException() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new OrbitSnapshot(SolarSystemBody.EARTH, CENTER, 0.0, 100.0, TWO_POSITIONS, 0));
+  }
+
+  @Test
+  void negativePeriodSeconds_throwsIllegalArgumentException() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new OrbitSnapshot(SolarSystemBody.EARTH, CENTER, -1.0, 100.0, TWO_POSITIONS, 0));
+  }
+
+  @Test
+  void nanPeriodSeconds_throwsIllegalArgumentException() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new OrbitSnapshot(SolarSystemBody.EARTH, CENTER, Double.NaN, 100.0, TWO_POSITIONS, 0));
+  }
+
+  @Test
+  void zeroStepSeconds_throwsIllegalArgumentException() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new OrbitSnapshot(SolarSystemBody.EARTH, CENTER, 86400.0, 0.0, TWO_POSITIONS, 0));
+  }
+
+  @Test
+  void negativeStepSeconds_throwsIllegalArgumentException() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new OrbitSnapshot(SolarSystemBody.EARTH, CENTER, 86400.0, -1.0, TWO_POSITIONS, 0));
+  }
+
+  @Test
+  void nanStepSeconds_throwsIllegalArgumentException() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new OrbitSnapshot(
+                SolarSystemBody.EARTH, CENTER, 86400.0, Double.NaN, TWO_POSITIONS, 0));
+  }
+
+  @Test
+  void singlePosition_throwsIllegalArgumentException() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new OrbitSnapshot(
+                SolarSystemBody.EARTH, CENTER, 86400.0, 100.0, new Vector3D[] {Vector3D.ZERO}, 0));
+  }
+
+  @Test
+  void emptyPositions_throwsIllegalArgumentException() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new OrbitSnapshot(SolarSystemBody.EARTH, CENTER, 86400.0, 100.0, new Vector3D[0], 0));
+  }
+
+  @Test
+  void negativeVersion_throwsIllegalArgumentException() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new OrbitSnapshot(SolarSystemBody.EARTH, CENTER, 86400.0, 100.0, TWO_POSITIONS, -1));
+  }
+
+  @Test
+  void zeroVersion_isValid() {
+    assertDoesNotThrow(
+        () -> new OrbitSnapshot(SolarSystemBody.EARTH, CENTER, 86400.0, 100.0, TWO_POSITIONS, 0));
+  }
+
+  @Test
+  void largeVersion_isValid() {
+    assertDoesNotThrow(
+        () ->
+            new OrbitSnapshot(
+                SolarSystemBody.EARTH, CENTER, 86400.0, 100.0, TWO_POSITIONS, Long.MAX_VALUE));
+  }
+}

--- a/src/test/java/com/smousseur/orbitlab/simulation/source/LruCacheTest.java
+++ b/src/test/java/com/smousseur/orbitlab/simulation/source/LruCacheTest.java
@@ -1,0 +1,88 @@
+package com.smousseur.orbitlab.simulation.source;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class LruCacheTest {
+
+  @Test
+  void get_missingKey_returnsNull() {
+    LruCache<String, Integer> cache = new LruCache<>(3);
+    assertNull(cache.get("absent"));
+  }
+
+  @Test
+  void put_thenGet_returnsValue() {
+    LruCache<String, Integer> cache = new LruCache<>(3);
+    cache.put("a", 1);
+    assertEquals(1, cache.get("a"));
+  }
+
+  @Test
+  void put_overwritesExistingKey() {
+    LruCache<String, Integer> cache = new LruCache<>(3);
+    cache.put("a", 1);
+    cache.put("a", 42);
+    assertEquals(42, cache.get("a"));
+  }
+
+  @Test
+  void containsKey_presentKey_returnsTrue() {
+    LruCache<String, Integer> cache = new LruCache<>(3);
+    cache.put("x", 99);
+    assertTrue(cache.containsKey("x"));
+  }
+
+  @Test
+  void containsKey_absentKey_returnsFalse() {
+    LruCache<String, Integer> cache = new LruCache<>(3);
+    assertFalse(cache.containsKey("missing"));
+  }
+
+  @Test
+  void eviction_leastRecentlyUsed_isEvicted() {
+    // capacity = 2: put a, b → then put c → 'a' (LRU) is evicted
+    LruCache<String, Integer> cache = new LruCache<>(2);
+    cache.put("a", 1);
+    cache.put("b", 2);
+    cache.put("c", 3); // 'a' is the LRU entry; it should be evicted
+    assertFalse(cache.containsKey("a"), "'a' should have been evicted");
+    assertTrue(cache.containsKey("b"));
+    assertTrue(cache.containsKey("c"));
+  }
+
+  @Test
+  void accessOrder_getPromotesEntry_preventingEviction() {
+    // capacity = 2: put a, b → access a (makes b LRU) → put c → 'b' is evicted
+    LruCache<String, Integer> cache = new LruCache<>(2);
+    cache.put("a", 1);
+    cache.put("b", 2);
+    cache.get("a"); // promote 'a'; now 'b' is LRU
+    cache.put("c", 3); // 'b' should be evicted
+    assertTrue(cache.containsKey("a"), "'a' was recently accessed and should survive");
+    assertFalse(cache.containsKey("b"), "'b' is now LRU and should be evicted");
+    assertTrue(cache.containsKey("c"));
+  }
+
+  @Test
+  void exactlyAtCapacity_noEviction() {
+    LruCache<Integer, Integer> cache = new LruCache<>(3);
+    cache.put(1, 10);
+    cache.put(2, 20);
+    cache.put(3, 30);
+    assertTrue(cache.containsKey(1));
+    assertTrue(cache.containsKey(2));
+    assertTrue(cache.containsKey(3));
+  }
+
+  @Test
+  void singleCapacity_evictsOnSecondPut() {
+    LruCache<String, Integer> cache = new LruCache<>(1);
+    cache.put("a", 1);
+    cache.put("b", 2);
+    assertFalse(cache.containsKey("a"));
+    assertTrue(cache.containsKey("b"));
+    assertEquals(2, cache.get("b"));
+  }
+}


### PR DESCRIPTION
- Translate 3 French inline comments to English (LightningAppState, EphemerisDatasetGenerator)
- Remove dead SimulationClock.listenersSnapshot() method (defined but never called)
- Fix MinAltitudeTracker: initialize maxAltitude to Double.NEGATIVE_INFINITY instead of Double.MIN_VALUE (semantically correct sentinel for tracking a maximum)
- Add OrbitPathTest: validates OrbitPath record construction constraints
- Add OrbitSnapshotTest: validates OrbitSnapshot record construction constraints
- Add LruCacheTest: verifies LRU eviction, access-order promotion, and basic get/put/containsKey behaviour
- Add OptimizationResultTest: verifies bestVariables() returns a defensive clone and stageEntryState is null in the 4-arg constructor

https://claude.ai/code/session_01XdxkSzpQVHAzeVwWVZ2ius