### PR TITLE
Update README with screenshots from issue #54

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,35 +28,28 @@ Fly through a physically accurate, animated solar system — for the sheer joy o
 
 > The rendering engine handles the extreme scale of space (Mercury's orbit vs. Pluto's) without any floating-point precision artifacts, keeping the view crisp at every zoom level.
 
+| | |
+|:---:|:---:|
+| ![Solar system overview](https://github.com/user-attachments/assets/34a932b2-425d-4ad6-97b0-b1b746eb84ea) | ![Planet close-up with orbit path](https://github.com/user-attachments/assets/8cf01fba-ba35-4e17-90b9-40cf83e316db) |
+
 ---
 
 ## 🛸 Space Mission Simulation
 
 Design and simulate rocket missions from launchpad to orbit — with automatic trajectory optimization.
 
-### Current capability: Low Earth Orbit (LEO)
+OrbitLab simulates a complete LEO launch campaign through five sequential phases:
 
-OrbitLab can simulate a complete LEO launch campaign:
-
-```
-  Liftoff
-    │
-    ▼ Vertical ascent          (burn straight up to clear the atmosphere)
-    │
-    ▼ Gravity turn             (pitch over and let gravity shape the trajectory)
-    │
-    ▼ Stage separation         (jettison spent booster stages)
-    │
-    ▼ Coasting arc             (follow a ballistic arc to apoapsis)
-    │
-    ▼ Circularization burn     (final burn to achieve circular orbit)
-    │
-    ▼ 🛰️ On station — LEO achieved!
-```
+| Phase | Screenshot |
+|---|:---:|
+| **Vertical ascent** — burn straight up to clear the atmosphere | ![Vertical ascent](https://github.com/user-attachments/assets/a18981f4-fa01-49fb-aac5-27f733df8fab) |
+| **Gravity turn** — pitch over and let gravity shape the trajectory | ![Gravity turn](https://github.com/user-attachments/assets/a2cbb0dd-e39f-483e-aa79-8b5215eb307c) |
+| **Coasting arc** — follow a ballistic arc to apoapsis | ![Coasting arc](https://github.com/user-attachments/assets/aa06d343-acc0-436c-b09c-caae5cf67feb) |
+| **Circularization burn** — final burn to achieve circular orbit | ![Circularization burn](https://github.com/user-attachments/assets/a17ff4a5-b8ee-43ab-a2df-4e36c6efb1b7) |
 
 **Key features:**
 - **Multi-stage rocket definition** — model your vehicle's mass, thrust, and ISP for each stage
-- **Automatic trajectory optimization** — OrbitLab searches for the optimal gravity-turn profile to hit your target orbit altitude
+- **Automatic trajectory optimization** — OrbitLab uses CMA-ES to find the optimal gravity-turn profile for your target orbit altitude
 - **High-fidelity physics** — Earth's gravitational field (including oblateness effects) is modeled for realistic trajectory computation
 - **Deterministic replay** — once optimized, missions are replayed step-by-step and visualized in 3D
 


### PR DESCRIPTION
Add screenshots to the 3D Solar System Visualization section and completely redo the Space Mission Simulation section with a visual phase-by-phase table using screenshots. Remove the "Current capability: Low Earth Orbit (LEO)" heading.

https://claude.ai/code/session_01S2ykAu4i8Js4uuQZbcn1qp